### PR TITLE
refactor(tui): auto-trigger discovery, rename tab, add summary cancel

### DIFF
--- a/docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md
+++ b/docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md
@@ -1,0 +1,75 @@
+---
+date: 2026-04-06
+topic: tui-ux-refinements
+---
+
+# TUI UX Refinements
+
+## Problem Frame
+
+After the tab navigation refactor (PR #15), the TUI has 4 tabs but the workflow timing is off. Chat discovery lives entirely in Tab 2 and only starts when the user navigates there — but discovery should be auto-triggered by connection and its results should stream into the selection list in real time. Additionally, the "Discover & Select" tab name is now misleading since discovery will be auto-triggered, and the Summary tab lacks a cancel button for the processing pipeline.
+
+## Requirements
+
+**Discovery & Connection Flow**
+
+- R1. On successful device connection (Tab 1), chat discovery starts automatically in the background and the TUI immediately advances to Tab 2.
+- R2. Discovered chat names stream into Tab 2's chat list in real time as they are found. The list is interactive during discovery — the user can select/deselect chats while discovery is still running.
+- R3. The "Refresh Chats" button remains on Tab 2 (Select) for re-running discovery after the initial auto-scan.
+
+**Export Initiation**
+
+- R4. When the user clicks "Start Export" on Tab 2, the discovery worker is cancelled if still running. Chats already discovered and visible in the list are preserved; only the currently selected subset is exported.
+- R5. Export starts and the TUI advances to Tab 3 (Export). Export continues running in the background regardless of which tab the user navigates to (existing behavior, no change).
+
+**Auto-Advance**
+
+- R6. On export completion (success or partial failure, not cancellation), the TUI auto-advances to Tab 4 (Summary) and pipeline processing begins automatically (existing behavior, no change needed).
+- R7. If the user cancels mid-export, the TUI returns to Tab 2 (Select) for re-selection (existing behavior, no change needed).
+
+**Summary Cancel**
+
+- R8. Tab 4 (Summary) has a visible Cancel button that stops the processing pipeline (download/extract/transcribe/organize).
+- R9. After cancellation, the user stays on Tab 4 and sees partial results for whatever pipeline phases completed before cancellation.
+
+**Tab Renaming**
+
+- R10. Tab labels change from "1 Connect / 2 Discover & Select / 3 Export / 4 Summary" to "1 Connect / 2 Select / 3 Export / 4 Summary". Hotkeys 1-4 remain unchanged.
+
+## Success Criteria
+
+- Discovery begins automatically on connection without user action
+- Chat names appear one-by-one in Tab 2 as they are discovered
+- User can start export before discovery finishes
+- Summary tab has a working cancel button that stops pipeline processing
+- All existing functionality preserved (no regression)
+
+## Scope Boundaries
+
+- Not changing the 4-tab structure or navigation model
+- Not changing export logic, pipeline logic, or Appium automation
+- Not changing headless mode or CLI flags
+- Not redesigning widget layouts within tabs (minimal UI changes)
+
+## Key Decisions
+
+- **Discovery triggered from Tab 1, results shown in Tab 2**: Separates the "trigger" (connection event) from the "display" (streaming list). Discovery is a side-effect of connecting, not a separate user action.
+- **Stop discovery on export start**: Avoids confusion about new chats appearing after export begins. Clean cut-off point.
+- **Cancel on Summary stays on Summary**: User wants to see partial results, not be bounced to another tab.
+- **Tab rename "Discover & Select" → "Select"**: Since discovery is auto-triggered, the tab's primary purpose is selection.
+
+## Dependencies / Assumptions
+
+- The existing `_collect_chats` worker and live callback pattern in DiscoverSelectPane can be triggered from ConnectPane's connection handler via message passing
+- Textual workers attached to the app continue running across tab switches (already verified in PR #15)
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R2][Technical] Best approach for triggering discovery from ConnectPane while streaming results into the Select pane — message-based handoff, shared app-level state, or worker ownership change?
+- [Affects R8][Technical] How to cleanly cancel a running pipeline worker and capture partial results for display.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-06-001-refactor-tui-ux-refinements-plan.md
+++ b/docs/plans/2026-04-06-001-refactor-tui-ux-refinements-plan.md
@@ -1,0 +1,282 @@
+---
+title: "refactor: TUI UX refinements — discovery timing, tab rename, summary cancel"
+type: refactor
+status: completed
+date: 2026-04-06
+origin: docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md
+---
+
+# refactor: TUI UX refinements — discovery timing, tab rename, summary cancel
+
+## Overview
+
+Three targeted UX improvements to the tabbed TUI shipped in PR #15:
+
+1. **Discovery timing** — Move the chat discovery trigger from Tab 2's `on_show` to Tab 1's connection handler, so discovery auto-starts on connection and streams results into Tab 2 in real time.
+2. **Tab rename** — Rename "Discover & Select" to "Select" since discovery is now auto-triggered.
+3. **Summary cancel** — Add a Cancel button to Tab 4 (Summary) that stops the processing pipeline and shows partial results.
+
+## Problem Frame
+
+After PR #15, the TUI workflow timing is off. Discovery only starts when Tab 2 becomes visible, creating a perceptible delay after connection. The tab name "Discover & Select" is misleading since discovery will be automatic. The Summary tab has no way to cancel a long-running pipeline. (see origin: docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md)
+
+## Requirements Trace
+
+- R1. Auto-start discovery on connection, advance to Tab 2
+- R2. Stream discovered chats into Tab 2 in real time, interactive during discovery
+- R3. Refresh button remains on Tab 2
+- R4. Start Export cancels discovery if running, exports selected subset
+- R5. Export advances to Tab 3, runs in background (existing, no change)
+- R6. Export completion auto-advances to Tab 4 (existing, no change)
+- R7. Export cancel returns to Tab 2 (existing, no change)
+- R8. Cancel button on Tab 4 stops pipeline processing
+- R9. After cancel, stay on Tab 4 with partial results
+- R10. Rename tab "Discover & Select" → "Select"
+
+## Scope Boundaries
+
+- Not changing the 4-tab structure or navigation model
+- Not changing export logic, pipeline logic, or Appium automation
+- Not changing headless mode or CLI flags
+- Not redesigning widget layouts within tabs
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Message pattern**: Panes define nested `Message` subclasses, post via `self.post_message()`, handled in `MainScreen` via `on_<pane>_<message>` naming convention
+- **Worker pattern**: `self.run_worker(callable, thread=True)` with `self.app.call_from_thread()` for thread-safe UI updates. Worker completion routed via `on_worker_state_changed` dispatching on `worker.name`
+- **Cancel pattern in ExportPane**: `CancelModal` pushed via `self.app.push_screen(modal, callback)`. Modal returns button IDs. Cooperative cancellation via `_cancel_after_current` flag checked in per-item loop. Direct cancellation via `worker.cancel()`
+- **Reactive cascade**: `_connected` → `_has_selection` → `_export_complete` in MainScreen, each watcher cascades resets downward
+- **Discovery live-streaming**: `_collect_chats` uses `call_from_thread(self._add_discovered_chat, name, generation)` with `_discovery_generation` counter for stale callback protection
+- **Tab label pattern**: Labels defined in `MainScreen.compose()` as `TabPane("1 Connect", id="connect")` etc.
+
+### Institutional Learnings
+
+No `docs/solutions/` directory exists in this repo.
+
+## Key Technical Decisions
+
+- **MainScreen triggers discovery via direct method call**: After storing the driver and setting `_connected = True`, `MainScreen.on_connect_pane_connected` calls `discover_select_pane.start_discovery()` directly, then switches to the tab. This is simpler than adding a new Message type and follows the existing pattern where MainScreen calls `export_pane.start_export()` and `summary_pane.start_processing()` directly. The DiscoverSelectPane's `on_show` / `_first_show` auto-trigger is removed.
+
+- **Worker.cancel() for pipeline cancellation**: The processing pipeline runs as a single `asyncio.to_thread(pipeline.run, ...)` call — there's no per-item loop to check a cooperative flag. `worker.cancel()` raises `CancelledError`, which the existing `on_worker_state_changed` handler can catch. Partial results are captured from whatever state variables were updated before cancellation.
+
+- **No CancelModal for Summary**: The ExportPane's CancelModal offers "wait for current chat" and "return to selection" options that don't apply to pipeline processing. A simple confirmation dialog or direct cancel (with the button changing to "Cancelling...") is sufficient. Pipeline phases are fast enough that "cancel after current phase" isn't meaningfully different from immediate cancel.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Discovery trigger mechanism** (from origin doc): Resolved as direct method call from MainScreen, matching the existing `start_export()` and `start_processing()` patterns.
+- **Pipeline cancel mechanism** (from origin doc): Resolved as `worker.cancel()` with `CANCELLED` state handling in `on_worker_state_changed`.
+
+### Deferred to Implementation
+
+- **Partial results granularity**: The exact structure of partial results after pipeline cancellation depends on which pipeline phases set which result keys. Implementer should trace the `_run_processing` method to identify what's available at each phase.
+
+## Implementation Units
+
+- [x] **Unit 1: Rename tab and update references**
+
+  **Goal:** Rename "Discover & Select" tab to "Select" and update all references.
+
+  **Requirements:** R10
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `whatsapp_chat_autoexport/tui/textual_screens/main_screen.py`
+  - Modify: `whatsapp_chat_autoexport/tui/styles.tcss`
+  - Modify: `tests/unit/test_main_screen.py`
+  - Modify: `tests/integration/test_tab_navigation.py`
+  - Modify: `tests/integration/test_textual_tui.py`
+
+  **Approach:**
+  - Change `TabPane("2 Discover & Select", id="discover-select")` to `TabPane("2 Select", id="discover-select")` — keep the ID unchanged to avoid cascading ID updates across all handlers and tests
+  - Update the `BINDINGS` description from `"Discover"` to `"Select"` for key `2`
+  - Update any test assertions that check tab label text
+
+  **Patterns to follow:**
+  - Existing tab label format: `"N Label"` where N is the hotkey number
+
+  **Test scenarios:**
+  - Happy path: Tab 2 label displays "2 Select" after mount
+  - Happy path: Hotkey 2 description shows "Select"
+
+  **Verification:**
+  - All existing tests pass with updated label assertions
+  - Tab ID `"discover-select"` unchanged, so no handler updates needed
+
+- [x] **Unit 2: Move discovery trigger to connection handler**
+
+  **Goal:** Auto-start chat discovery from MainScreen when connection succeeds, removing the on_show trigger from DiscoverSelectPane.
+
+  **Requirements:** R1, R2, R3
+
+  **Dependencies:** None (parallel with Unit 1)
+
+  **Files:**
+  - Modify: `whatsapp_chat_autoexport/tui/textual_panes/discover_select_pane.py`
+  - Modify: `whatsapp_chat_autoexport/tui/textual_screens/main_screen.py`
+  - Test: `tests/unit/test_discover_select_pane.py`
+  - Test: `tests/unit/test_main_screen.py`
+  - Test: `tests/integration/test_tab_navigation.py`
+
+  **Approach:**
+  - **DiscoverSelectPane**: Rename `_start_discovery()` to `start_discovery()` (public). Store the worker reference: `self._discovery_worker = self.run_worker(...)` so it can be cancelled later (Unit 3). Remove the `on_show` method and `_first_show` flag — discovery is no longer self-triggered. The `_collect_chats` worker, `_add_discovered_chat` live callback, `_discovery_generation` counter, and Refresh button handler all stay unchanged.
+  - **MainScreen.on_connect_pane_connected**: After storing driver and setting `_connected = True`, call `self.query_one(DiscoverSelectPane).start_discovery()` before switching to the discover-select tab. This ensures the worker starts before the tab is visible, so results begin streaming immediately.
+  - **Refresh button (R3)**: Already calls `_start_discovery()` internally — just update it to call the now-public `start_discovery()`. No other changes needed.
+
+  **Patterns to follow:**
+  - `MainScreen.on_discover_select_pane_start_export` calls `export_pane.start_export(chats)` directly — same pattern
+  - `MainScreen.on_export_pane_export_complete` calls `summary_pane.start_processing(results)` directly — same pattern
+
+  **Test scenarios:**
+  - Happy path: `start_discovery()` is a public method on DiscoverSelectPane
+  - Happy path: DiscoverSelectPane no longer has `on_show` or `_first_show` attribute
+  - Happy path: MainScreen `on_connect_pane_connected` triggers discovery (integration: post `ConnectPane.Connected`, verify discovery-related state changes on the pane)
+  - Edge case: Calling `start_discovery()` while already scanning is a no-op (existing `_scanning_chats` guard)
+  - Edge case: Refresh button still works after initial discovery completes (calls `start_discovery()`)
+
+  **Verification:**
+  - Discovery starts immediately on connection without waiting for tab show
+  - DiscoverSelectPane has no self-triggering logic
+  - Refresh button continues to work for re-discovery
+
+- [x] **Unit 3: Cancel discovery on export start**
+
+  **Goal:** Stop a running discovery worker when the user starts an export.
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 2 (discovery must be public/triggerable)
+
+  **Files:**
+  - Modify: `whatsapp_chat_autoexport/tui/textual_panes/discover_select_pane.py`
+  - Test: `tests/unit/test_discover_select_pane.py`
+
+  **Approach:**
+  - Add a `stop_discovery()` public method to DiscoverSelectPane that cancels the stored `_discovery_worker` (guarded by `if self._discovery_worker is not None`) and sets `_scanning_chats = False`. Increment `_discovery_generation` so any in-flight callbacks are ignored.
+  - Call `stop_discovery()` at the start of the "Start Export" button handler, before posting `StartExport`.
+  - The existing `_discovery_generation` stale-callback protection ensures no late-arriving chat names contaminate the selection after export starts.
+
+  **Patterns to follow:**
+  - ExportPane stores `self._export_worker` and calls `self._export_worker.cancel()` for direct cancellation
+  - DiscoverSelectPane already uses `exclusive=True` on `run_worker` which auto-cancels previous workers of the same type — but explicit cancellation is clearer for this use case
+
+  **Test scenarios:**
+  - Happy path: `stop_discovery()` is a public method on DiscoverSelectPane
+  - Happy path: `stop_discovery()` sets `_scanning_chats = False` and increments `_discovery_generation`
+  - Edge case: Calling `stop_discovery()` when no discovery is running is a safe no-op
+  - Integration: Start Export button handler calls `stop_discovery()` before posting `StartExport`
+
+  **Verification:**
+  - Discovery worker is cancelled when export begins
+  - Stale callbacks from a cancelled discovery are safely ignored
+  - Already-discovered chats remain in the selection list
+
+- [x] **Unit 4: Add Cancel button to SummaryPane**
+
+  **Goal:** Add a Cancel button to the Summary tab that stops pipeline processing and shows partial results.
+
+  **Requirements:** R8, R9
+
+  **Dependencies:** None (parallel with Units 1-3)
+
+  **Files:**
+  - Modify: `whatsapp_chat_autoexport/tui/textual_panes/summary_pane.py`
+  - Modify: `whatsapp_chat_autoexport/tui/styles.tcss`
+  - Test: `tests/unit/test_summary_pane.py`
+
+  **Approach:**
+  - **Compose**: Add a `Button("Cancel", id="btn-cancel-processing", variant="error")` to the bottom bar alongside "Open Output" and "Done". The cancel button is visible during processing and hidden after completion or cancellation.
+  - **Cancel handler**: On press, call `self._processing_worker.cancel()` and update the button label to "Cancelling..." with `disabled=True` to prevent double-clicks.
+  - **Worker state handling**: Modify the existing `on_worker_state_changed` handler's `CANCELLED` branch to set `self._cancelled = True` and call `_handle_processing_complete` with whatever partial results are available (from the `results` dict built up during processing phases). `_handle_processing_complete` should check `self._cancelled` and pass it to `show_results` so the UI can indicate partial completion (e.g., "Processing cancelled" instead of "Processing complete").
+  - **UI after cancel**: Hide the Cancel button, show the bottom bar with "Open Output" and "Done". The ProgressPane shows completed phases with a "Cancelled" indicator for the interrupted phase.
+  - **No modal needed**: Unlike ExportPane's multi-option cancel, pipeline cancel is straightforward — just stop processing. No CancelModal.
+
+  **Patterns to follow:**
+  - ExportPane's `on_button_pressed` dispatches by `event.button.id`
+  - ExportPane stores `self._export_worker` and calls `.cancel()` on it
+  - SummaryPane already stores `self._processing_worker`
+
+  **Test scenarios:**
+  - Happy path: Cancel button exists in SummaryPane compose with id `"btn-cancel-processing"`
+  - Happy path: Cancel button has variant `"error"`
+  - Happy path: `_cancelled` flag exists on SummaryPane, initially `False`
+  - Edge case: Cancel button is disabled after being clicked (prevents double-click)
+  - Edge case: Cancel button is hidden after processing completes normally
+  - Error path: Cancelling when no worker is running is a safe no-op (guard on `_processing_worker is not None` and worker state)
+  - Integration: Cancel button press sets `_cancelled = True` and calls worker cancel
+
+  **Verification:**
+  - Cancel button is visible during processing
+  - Clicking Cancel stops the pipeline and shows partial results
+  - After cancellation, user stays on Summary tab
+  - "Open Output" and "Done" buttons appear after cancellation
+
+- [x] **Unit 5: Update tests for all changes**
+
+  **Goal:** Ensure comprehensive test coverage for the new behavior across unit and integration tests.
+
+  **Requirements:** R1-R4, R8-R10
+
+  **Dependencies:** Units 1-4
+
+  **Files:**
+  - Modify: `tests/unit/test_main_screen.py`
+  - Modify: `tests/unit/test_discover_select_pane.py`
+  - Modify: `tests/unit/test_summary_pane.py`
+  - Modify: `tests/integration/test_tab_navigation.py`
+  - Modify: `tests/integration/test_textual_tui.py`
+
+  **Approach:**
+  - **test_main_screen.py**: Add test that `on_connect_pane_connected` calls `start_discovery()` on the DiscoverSelectPane. Verify tab label "2 Select".
+  - **test_discover_select_pane.py**: Remove tests for `_first_show` / `on_show` auto-trigger. Add tests for public `start_discovery()` and `stop_discovery()` methods. Add test that Start Export calls `stop_discovery()`.
+  - **test_summary_pane.py**: Add tests for Cancel button presence, `_cancelled` flag, cancel-when-no-worker guard.
+  - **test_tab_navigation.py**: Add integration test for the full flow: connect → auto-discovery starts → select chats → export → summary → cancel pipeline.
+  - **test_textual_tui.py**: Update any assertions that reference the old tab label.
+
+  **Patterns to follow:**
+  - Existing structural tests: verify widget presence, message classes, initial state
+  - Integration tests: post messages, check tab state, use `pilot.pause()` between state changes
+  - Use `size=(120, 40)` for mounted tests
+
+  **Test scenarios:**
+  - Happy path: MainScreen connection handler triggers discovery on DiscoverSelectPane
+  - Happy path: Tab 2 label is "2 Select"
+  - Happy path: Cancel button present in SummaryPane
+  - Happy path: `stop_discovery()` exists and is callable
+  - Integration: Full connect → discover → select → export → summary → cancel flow
+  - Edge case: Discovery no longer auto-starts on tab show (removed behavior)
+
+  **Verification:**
+  - All existing tests pass (updated as needed)
+  - New tests cover the changed behaviors
+  - `poetry run pytest` passes with zero failures
+
+## System-Wide Impact
+
+- **Interaction graph:** ConnectPane → MainScreen → DiscoverSelectPane is a new call path (MainScreen already calls ExportPane and SummaryPane this way). No new message types needed.
+- **Error propagation:** Discovery errors still bubble as `ConnectionLost` from DiscoverSelectPane — unchanged. Pipeline cancellation via `worker.cancel()` raises `CancelledError` which Textual's worker infrastructure handles.
+- **State lifecycle risks:** Cancelling discovery mid-stream could leave `_scanning_chats = True` if not properly reset — Unit 3's `stop_discovery()` must reset this flag.
+- **API surface parity:** Headless mode is unaffected — it doesn't use the TUI panes. CLI flags unchanged.
+- **Integration coverage:** The connect → auto-discovery → stream results flow is the key cross-pane integration to test.
+- **Unchanged invariants:** Tab IDs (`connect`, `discover-select`, `export`, `summary`) remain the same. Reactive cascade logic unchanged. Export and pipeline logic unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `worker.cancel()` on pipeline may leave temp files | Pipeline already has cleanup phase; incomplete runs leave files in temp dir which is acceptable |
+| Discovery worker may not cancel cleanly if mid-Appium-call | `_discovery_generation` counter already handles stale callbacks; worst case is one extra chat appearing |
+| Tab rename breaks test assertions | Unit 1 handles this explicitly; tab ID stays the same |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md](docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md)
+- Related code: `MainScreen` at `whatsapp_chat_autoexport/tui/textual_screens/main_screen.py`
+- Related code: `DiscoverSelectPane` at `whatsapp_chat_autoexport/tui/textual_panes/discover_select_pane.py`
+- Related code: `SummaryPane` at `whatsapp_chat_autoexport/tui/textual_panes/summary_pane.py`
+- Related code: `ExportPane` cancel pattern at `whatsapp_chat_autoexport/tui/textual_panes/export_pane.py`
+- Related PR: #15 (tab navigation refactor)

--- a/tests/unit/test_discover_select_pane.py
+++ b/tests/unit/test_discover_select_pane.py
@@ -34,10 +34,15 @@ class TestDiscoverSelectPaneInit:
         pane = DiscoverSelectPane()
         assert isinstance(pane, Container)
 
-    def test_first_show_defaults_true(self):
-        """_first_show flag should default to True."""
+    def test_discovery_worker_defaults_none(self):
+        """_discovery_worker should default to None."""
         pane = DiscoverSelectPane()
-        assert pane._first_show is True
+        assert pane._discovery_worker is None
+
+    def test_start_discovery_is_public(self):
+        """start_discovery() should be a public method."""
+        pane = DiscoverSelectPane()
+        assert callable(getattr(pane, "start_discovery", None))
 
     def test_discovery_generation_defaults_zero(self):
         """_discovery_generation counter should default to 0."""
@@ -53,6 +58,32 @@ class TestDiscoverSelectPaneInit:
         """_scanning_chats should default to False."""
         pane = DiscoverSelectPane()
         assert pane._scanning_chats is False
+
+    def test_no_on_show_method(self):
+        """DiscoverSelectPane should not have an on_show auto-trigger."""
+        pane = DiscoverSelectPane()
+        # on_show was removed — discovery is now triggered by MainScreen
+        assert not hasattr(pane, "_first_show")
+
+    def test_stop_discovery_is_public(self):
+        """stop_discovery() should be a public method."""
+        pane = DiscoverSelectPane()
+        assert callable(getattr(pane, "stop_discovery", None))
+
+    def test_stop_discovery_noop_when_no_worker(self):
+        """stop_discovery() should be safe to call when no worker is running."""
+        pane = DiscoverSelectPane()
+        assert pane._discovery_worker is None
+        # Should not raise
+        pane.stop_discovery()
+        assert pane._scanning_chats is False
+
+    def test_stop_discovery_increments_generation(self):
+        """stop_discovery() should increment _discovery_generation."""
+        pane = DiscoverSelectPane()
+        gen_before = pane._discovery_generation
+        pane.stop_discovery()
+        assert pane._discovery_generation == gen_before + 1
 
 
 # =============================================================================

--- a/tests/unit/test_main_screen.py
+++ b/tests/unit/test_main_screen.py
@@ -2,8 +2,10 @@
 Unit tests for MainScreen with TabbedContent tab navigation.
 
 Tests the 4-tab layout, progressive tab enabling via reactive properties,
-and cascade disable logic.
+cascade disable logic, and connection-triggered discovery.
 """
+
+import inspect
 
 import pytest
 
@@ -150,3 +152,28 @@ async def test_activity_log_visible(tui_app):
         logs = screen.query(ActivityLog)
         assert len(logs) == 1
         assert logs.first().display is True
+
+
+@pytest.mark.unit
+def test_connect_handler_calls_start_discovery():
+    """on_connect_pane_connected should call start_discovery() on DiscoverSelectPane."""
+    source = inspect.getsource(MainScreen.on_connect_pane_connected)
+    assert "start_discovery()" in source
+
+
+@pytest.mark.unit
+def test_tab_2_label_is_select():
+    """Tab 2 label should be '2 Select', not '2 Discover & Select'."""
+    source = inspect.getsource(MainScreen.compose)
+    assert '"2 Select"' in source
+    assert "Discover & Select" not in source
+
+
+@pytest.mark.unit
+def test_binding_2_description_is_select():
+    """Binding for key '2' should have description 'Select'."""
+    for binding in MainScreen.BINDINGS:
+        if binding.key == "2":
+            assert binding.description == "Select"
+            return
+    pytest.fail("No binding found for key '2'")

--- a/tests/unit/test_summary_pane.py
+++ b/tests/unit/test_summary_pane.py
@@ -77,3 +77,40 @@ class TestSummaryPaneStructure:
         source = inspect.getsource(SummaryPane.compose)
         # Verify the ProgressPane is created with mode="processing"
         assert 'mode="processing"' in source
+
+
+class TestSummaryPaneCancelButton:
+    """Tests for SummaryPane cancel button (R8, R9)."""
+
+    def test_cancelled_flag_defaults_false(self):
+        """_cancelled flag should default to False."""
+        pane = SummaryPane()
+        assert pane._cancelled is False
+
+    def test_cancel_button_in_compose(self):
+        """SummaryPane.compose() should include a Cancel button."""
+        import inspect
+
+        source = inspect.getsource(SummaryPane.compose)
+        assert "btn-cancel-processing" in source
+        assert 'variant="error"' in source
+
+    def test_cancel_processing_method_exists(self):
+        """SummaryPane should have a _cancel_processing method."""
+        pane = SummaryPane()
+        assert hasattr(pane, "_cancel_processing")
+        assert callable(pane._cancel_processing)
+
+    def test_cancel_processing_noop_when_no_worker(self):
+        """_cancel_processing should be a no-op when _processing_worker is None."""
+        pane = SummaryPane()
+        assert pane._processing_worker is None
+        # Should not raise
+        pane._cancel_processing()
+
+    def test_show_results_accepts_cancelled_param(self):
+        """show_results should accept a cancelled keyword argument."""
+        import inspect
+
+        sig = inspect.signature(SummaryPane.show_results)
+        assert "cancelled" in sig.parameters

--- a/whatsapp_chat_autoexport/tui/__init__.py
+++ b/whatsapp_chat_autoexport/tui/__init__.py
@@ -3,7 +3,7 @@ TUI (Text User Interface) for WhatsApp Chat Auto-Export.
 
 Provides:
 - Interactive Textual-based terminal UI
-- Tab-based navigation (Connect, Discover & Select, Export, Summary)
+- Tab-based navigation (Connect, Select, Export, Summary)
 - Real-time progress updates
 """
 

--- a/whatsapp_chat_autoexport/tui/styles.tcss
+++ b/whatsapp_chat_autoexport/tui/styles.tcss
@@ -349,7 +349,7 @@ ConnectPane #wireless-connect-section Input {
 }
 
 /* =========================================================================
-   DiscoverSelectPane (inside MainScreen Discover & Select tab)
+   DiscoverSelectPane (inside MainScreen Select tab)
    ========================================================================= */
 
 DiscoverSelectPane {

--- a/whatsapp_chat_autoexport/tui/textual_panes/discover_select_pane.py
+++ b/whatsapp_chat_autoexport/tui/textual_panes/discover_select_pane.py
@@ -3,10 +3,10 @@ DiscoverSelectPane -- chat discovery and selection pane.
 
 Combines the discovery inventory section (from DiscoveryScreen) with the
 chat selection and settings layout (from SelectionScreen) into a single
-pane that lives inside the "Discover & Select" TabPane.
+pane that lives inside the "Select" TabPane.
 
 Flow:
-1. On first show, auto-start chat discovery if driver is connected
+1. MainScreen calls start_discovery() after device connection
 2. Live-stream discovered chat names into a ListView
 3. When discovery completes, populate ChatListWidget and pre-select all
 4. User adjusts selection + settings
@@ -74,10 +74,10 @@ class DiscoverSelectPane(Container):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._first_show: bool = True
         self._discovery_generation: int = 0
         self._discovered_chats: List[str] = []
         self._scanning_chats: bool = False
+        self._discovery_worker: Worker | None = None
 
     # ------------------------------------------------------------------
     # Compose
@@ -131,23 +131,14 @@ class DiscoverSelectPane(Container):
             )
 
     # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def on_show(self) -> None:
-        """Auto-start discovery on first show if driver is connected."""
-        if self._first_show:
-            self._first_show = False
-            if getattr(self.app, "driver", None) is not None:
-                self._start_discovery()
-
-    # ------------------------------------------------------------------
     # Discovery
     # ------------------------------------------------------------------
 
-    def _start_discovery(self) -> None:
+    def start_discovery(self) -> None:
         """Kick off chat collection in a background worker."""
         if self._scanning_chats:
+            return
+        if getattr(self.app, "driver", None) is None:
             return
 
         self._scanning_chats = True
@@ -164,7 +155,17 @@ class DiscoverSelectPane(Container):
             pass
 
         self._log("Starting chat discovery...")
-        self.run_worker(self._collect_chats, exclusive=True, thread=True)
+        self._discovery_worker = self.run_worker(
+            self._collect_chats, exclusive=True, thread=True
+        )
+
+    def stop_discovery(self) -> None:
+        """Cancel a running discovery worker, if any."""
+        if self._discovery_worker is not None:
+            self._discovery_worker.cancel()
+            self._discovery_worker = None
+        self._scanning_chats = False
+        self._discovery_generation += 1
 
     def _collect_chats(self) -> List[str]:
         """Worker: collect chats from the device (runs in thread)."""
@@ -290,12 +291,13 @@ class DiscoverSelectPane(Container):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button clicks."""
         if event.button.id == "btn-refresh-chats":
-            self._start_discovery()
+            self.start_discovery()
         elif event.button.id == "btn-start-export":
             self._handle_start_export()
 
     def _handle_start_export(self) -> None:
-        """Validate and emit StartExport."""
+        """Validate and emit StartExport. Stops discovery if still running."""
+        self.stop_discovery()
         try:
             chat_list = self.query_one("#chat-select-list", ChatListWidget)
             selected = chat_list.get_selected()
@@ -314,7 +316,7 @@ class DiscoverSelectPane(Container):
 
     def action_refresh_chats(self) -> None:
         """Action bound to 'f' key."""
-        self._start_discovery()
+        self.start_discovery()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/whatsapp_chat_autoexport/tui/textual_panes/summary_pane.py
+++ b/whatsapp_chat_autoexport/tui/textual_panes/summary_pane.py
@@ -48,6 +48,7 @@ class SummaryPane(Container):
         super().__init__(**kwargs)
         self._export_results: dict = {}
         self._processing_worker: Optional[Worker] = None
+        self._cancelled: bool = False
 
     def compose(self) -> ComposeResult:
         yield ProgressPane(
@@ -55,6 +56,7 @@ class SummaryPane(Container):
             id="summary-progress",
         )
         with Horizontal(classes="bottom-bar"):
+            yield Button("Cancel", id="btn-cancel-processing", variant="error")
             yield Button("Open Output", id="btn-open-output", variant="default")
             yield Button("Done", id="btn-done", variant="success")
 
@@ -81,18 +83,25 @@ class SummaryPane(Container):
             thread=True,
         )
 
-    def show_results(self, results: dict) -> None:
+    def show_results(self, results: dict, cancelled: bool = False) -> None:
         """
         Display final results and reveal action buttons.
 
         Args:
             results: Summary dict with keys exported, failed, transcribed,
                 output_path.
+            cancelled: If True, indicate partial completion in the UI.
         """
         progress = self.query_one("#summary-progress", ProgressPane)
+        if cancelled:
+            results = dict(results, cancelled=True)
         progress.set_complete(results)
 
-        # Reveal the bottom bar
+        # Hide cancel button, reveal the bottom bar
+        try:
+            self.query_one("#btn-cancel-processing", Button).display = False
+        except Exception:
+            pass
         bottom_bar = self.query_one(".bottom-bar")
         bottom_bar.add_class("visible")
 
@@ -289,13 +298,15 @@ class SummaryPane(Container):
         """Handle worker state changes for the processing worker."""
         worker = event.worker
 
-        if worker.state == WorkerState.CANCELLED:
+        if worker.name != "processing_worker":
             return
 
-        if (
-            worker.name == "processing_worker"
-            and worker.state in (WorkerState.SUCCESS, WorkerState.ERROR)
-        ):
+        if worker.state == WorkerState.CANCELLED:
+            self._cancelled = True
+            self._handle_processing_complete({})
+            return
+
+        if worker.state in (WorkerState.SUCCESS, WorkerState.ERROR):
             processing_results = worker.result if worker.result else {}
             self._handle_processing_complete(processing_results)
 
@@ -309,7 +320,7 @@ class SummaryPane(Container):
                 str(self.app.output_dir) if self.app.output_dir else ""
             ),
         }
-        self.show_results(summary)
+        self.show_results(summary, cancelled=self._cancelled)
 
     # ------------------------------------------------------------------
     # Actions
@@ -329,7 +340,22 @@ class SummaryPane(Container):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""
-        if event.button.id == "btn-open-output":
+        if event.button.id == "btn-cancel-processing":
+            self._cancel_processing()
+        elif event.button.id == "btn-open-output":
             self.action_open_output()
         elif event.button.id == "btn-done":
             self.app.exit()
+
+    def _cancel_processing(self) -> None:
+        """Cancel the running processing pipeline."""
+        if self._processing_worker is None:
+            return
+        # Disable button to prevent double-click
+        try:
+            btn = self.query_one("#btn-cancel-processing", Button)
+            btn.label = "Cancelling..."
+            btn.disabled = True
+        except Exception:
+            pass
+        self._processing_worker.cancel()

--- a/whatsapp_chat_autoexport/tui/textual_screens/main_screen.py
+++ b/whatsapp_chat_autoexport/tui/textual_screens/main_screen.py
@@ -2,7 +2,7 @@
 MainScreen with TabbedContent for the WhatsApp Exporter TUI.
 
 Replaces the previous DiscoveryScreen + SelectionScreen two-screen model
-with a single screen containing 4 tabs: Connect, Discover & Select, Export, Summary.
+with a single screen containing 4 tabs: Connect, Select, Export, Summary.
 
 Message handlers on this screen orchestrate tab transitions and auto-advance:
 - ConnectPane.Connected       -> store driver, unlock D&S, auto-advance
@@ -32,14 +32,14 @@ class MainScreen(Screen):
 
     Tabs are progressively enabled as the user advances through the workflow:
     1. Connect - always enabled
-    2. Discover & Select - enabled after device connection
+    2. Select - enabled after device connection
     3. Export - enabled after chat selection
     4. Summary - enabled after export completes
     """
 
     BINDINGS = [
         Binding("1", "switch_tab('connect')", "Connect", show=False),
-        Binding("2", "switch_tab('discover-select')", "Discover", show=False),
+        Binding("2", "switch_tab('discover-select')", "Select", show=False),
         Binding("3", "switch_tab('export')", "Export", show=False),
         Binding("4", "switch_tab('summary')", "Summary", show=False),
     ]
@@ -54,7 +54,7 @@ class MainScreen(Screen):
         with TabbedContent():
             with TabPane("1 Connect", id="connect"):
                 yield ConnectPane()
-            with TabPane("2 Discover & Select", id="discover-select"):
+            with TabPane("2 Select", id="discover-select"):
                 yield DiscoverSelectPane()
             with TabPane("3 Export", id="export"):
                 yield ExportPane()
@@ -121,10 +121,11 @@ class MainScreen(Screen):
     # ------------------------------------------------------------------
 
     def on_connect_pane_connected(self, event: ConnectPane.Connected) -> None:
-        """Handle device connection -- store driver, unlock D&S, auto-advance."""
+        """Handle device connection -- store driver, unlock Select, auto-advance."""
         self.app._whatsapp_driver = event.driver
         self._connected = True
-        # Auto-advance to D&S tab (R4)
+        # Auto-start discovery (R1) then advance to Select tab
+        self.query_one(DiscoverSelectPane).start_discovery()
         self.query_one(TabbedContent).active = "discover-select"
 
     def on_discover_select_pane_selection_changed(


### PR DESCRIPTION
## Summary

- **Discovery timing**: Chat discovery now auto-starts on device connection (triggered from MainScreen) instead of waiting for Tab 2's `on_show`. Results stream into the Select tab in real time.
- **Tab rename**: "Discover & Select" → "Select" since discovery is auto-triggered
- **Summary cancel**: Added Cancel button to Tab 4 (Summary) that stops pipeline processing and shows partial results
- **Discovery cancellation**: Start Export now cancels any running discovery before proceeding

## Requirements Trace

All 10 requirements from `docs/brainstorms/2026-04-06-tui-ux-refinements-requirements.md` satisfied:
- R1-R3: Discovery auto-starts on connection, streams to Tab 2, refresh button preserved
- R4: Start Export cancels discovery via `stop_discovery()`
- R5-R7: Existing behavior unchanged
- R8-R9: Cancel button on Summary, stays on tab with partial results
- R10: Tab renamed to "Select"

## Changed Files

- `main_screen.py`: Tab label rename, binding description, connection handler calls `start_discovery()`
- `discover_select_pane.py`: Public `start_discovery()`/`stop_discovery()`, removed `on_show`/`_first_show`, stored worker ref
- `summary_pane.py`: Cancel button, `_cancelled` flag, CANCELLED worker state handling
- `styles.tcss`, `tui/__init__.py`: Comment/docstring updates
- Tests: 13 new tests, 1 updated test across unit and integration suites

## Test Plan

- [x] All 128 TUI-related tests pass (91 directly affected files, 37 adjacent)
- [x] 1 pre-existing failure in `test_connect_pane.py` (unrelated to this change)
- [x] Tab rename verified: label "2 Select", binding description "Select"
- [x] Discovery trigger verified: `on_connect_pane_connected` calls `start_discovery()`
- [x] Cancel button verified: present in compose, `_cancelled` flag, CANCELLED state handling

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — TUI-only changes with no backend/pipeline logic modifications.