### PR TITLE
docs(testing): three-tier testing protocol with five recipes

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -1,0 +1,243 @@
+---
+version: 1
+---
+
+# Testing — WhatsApp Chat AutoExport
+
+Read by `/aj-flow flow` Step 9 (Verify) and `/aj-flow review` Step 5 (Re-verify).
+See `aj-flow/PREFERENCES.md` → "Per-project testing conventions" for the contract.
+
+For human-friendly running instructions, see [`tests/README.md`](../tests/README.md).
+
+## Tiers — what each one is for
+
+| Tier | Where | Time budget | Catches | Doesn't catch |
+|---|---|---|---|---|
+| **Unit** | `tests/unit/` | ~30s focused, ~3min full | Logic regressions, mode dispatch, parsers, output builders. Mocks device + Drive + transcription. | Real Appium / Drive / API behaviour, real Textual UI rendering. |
+| **Integration (host-only)** | `tests/integration/` | ~1–2min | Textual `pilot` screen flow, CLI subprocess wiring, multi-component plumbing. Still mocks device + Drive + transcription. | Real device interaction, real upload, real transcription provider. |
+| **Manual (device-required)** | `tests/manual/` + the playbook below | 5–15min per pass | Appium UI scraping fragility, wireless-ADB pairing, real WhatsApp UI changes, Drive upload, `verify_whatsapp_is_open()` safety. | Anything not in the playbook (community chats, locked phone, expired pairing codes — documented as known limits). |
+
+## Surface coverage
+
+| Surface | Unit | Integration | Manual |
+|---|---|---|---|
+| **CLI** | `tests/unit/test_cli_entry.py`, `test_headless.py`, `test_pipeline_only.py`, `test_deprecated_entry.py` | `tests/integration/test_cli.py` + `whatsapp --help` smoke | `manual-device-export` |
+| **TUI** | `tests/unit/test_main_screen.py`, `test_connect_pane.py`, `test_export_pane.py`, … | `tests/integration/test_textual_tui.py`, `test_tab_navigation.py`, `test_connect_pane_preflight.py` | `manual-device-tui` |
+
+## Dev rig
+
+**Make available on PATH:**
+
+```bash
+poetry install --with dev
+```
+
+**Smoke-check binary is reachable:**
+
+```bash
+which whatsapp >/dev/null || { echo "whatsapp not on PATH"; exit 1; }
+```
+
+**Tear down:** nothing — no long-running services. The Textual pilot tests spin up the TUI in-process and tear it down per-test.
+
+## Recipes
+
+### `unit-fast`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/**"
+  - "tests/unit/**"
+  - "tests/integration/**"
+  - "pyproject.toml"
+  - ".claude/testing.md"
+tool: terminal
+artifacts:
+  - pytest.log
+pass: exit 0, all collected tests passed
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --tb=short --no-cov > assets/verification/<N>/unit-fast/pytest.log 2>&1`
+2. Pass iff exit 0.
+
+### `integration-cli`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/cli_entry.py"
+  - "whatsapp_chat_autoexport/headless.py"
+  - "whatsapp_chat_autoexport/pipeline.py"
+  - "whatsapp_chat_autoexport/deprecated_entry.py"
+  - "tests/integration/test_cli.py"
+tool: terminal
+artifacts:
+  - pytest.log
+  - help.log
+pass: exit 0 and `--headless` appears in help output
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/integration/test_cli.py -q --tb=short --no-cov > assets/verification/<N>/integration-cli/pytest.log 2>&1`
+2. `poetry run whatsapp --help > assets/verification/<N>/integration-cli/help.log 2>&1`
+3. Pass iff (1) exit 0 and `grep -q -- '--headless' assets/verification/<N>/integration-cli/help.log`.
+
+### `integration-tui`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/tui/**"
+  - "tests/integration/test_textual_tui.py"
+  - "tests/integration/test_tab_navigation.py"
+  - "tests/integration/test_connect_pane_preflight.py"
+tool: terminal
+artifacts:
+  - pytest.log
+pass: exit 0
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --tb=short --no-cov > assets/verification/<N>/integration-tui/pytest.log 2>&1`
+2. Pass iff exit 0.
+
+### `pipeline-on-fixtures`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/pipeline.py"
+  - "whatsapp_chat_autoexport/output/**"
+  - "whatsapp_chat_autoexport/export/archive_extractor.py"
+  - "whatsapp_chat_autoexport/transcription/**"
+tool: terminal
+artifacts:
+  - pipeline.log
+  - output-tree.txt
+pass: exit 0 and at least one non-empty file under <out>/transcripts/
+```
+
+**Steps:**
+
+1. Create a temp output dir under the verification artifacts root:
+   `OUT=assets/verification/<N>/pipeline-on-fixtures/out && mkdir -p "$OUT"`
+2. `poetry run whatsapp --pipeline-only sample_data "$OUT" --no-transcribe --no-output-media --skip-drive-download > assets/verification/<N>/pipeline-on-fixtures/pipeline.log 2>&1`
+3. `find "$OUT" > assets/verification/<N>/pipeline-on-fixtures/output-tree.txt`
+4. Pass iff (2) exit 0 and `find "$OUT/transcripts" -type f -size +0c -name "*.txt" | grep -q .`.
+
+### `manual-device-export` *(advisory — never auto-run)*
+
+```yaml
+trigger: []
+tool: manual
+artifacts: []
+pass: human-confirmed per the playbook below
+```
+
+**Why empty triggers:** the dispatcher only auto-runs recipes whose triggers match changed files. An empty trigger list guarantees this recipe is never auto-fired. The recipe exists so the doc surfaces the playbook in a single place; a contributor changing `export/`, `google_drive/`, or anything in the Appium path **must** read this and run it by hand.
+
+**Preconditions** (all required):
+
+- Phone unlocked, screen on, kept awake during the run.
+- WhatsApp installed and signed in on the phone.
+- USB debugging *or* wireless debugging paired with this Mac (`adb devices` shows the device).
+- Appium installed (`npm install -g appium`) and reachable on port 4723.
+- `OPENAI_API_KEY` *or* `ELEVENLABS_API_KEY` exported in the shell.
+- Google Drive signed in on the device.
+- Expected chat-list count ≈ 700+ (confirms WhatsApp UI is healthy on the device).
+
+**Command** (limited 2-chat smoke):
+
+```bash
+poetry run whatsapp --headless \
+  --output ~/whatsapp_test \
+  --auto-select \
+  --limit 2 \
+  --no-output-media
+```
+
+**Expected screen-by-screen** (terminal output highlights):
+
+1. **Preflight** — three probe lines (Whisper / ElevenLabs / Drive); none HARD FAIL.
+2. **Connect** — Appium starts; `WhatsApp connected` appears; `verify_whatsapp_is_open()` reports OK.
+3. **Discover** — chat-list collection runs (logs show pass 1, pass 2, ContactsContract reconciliation).
+4. **Select** — `--auto-select --limit 2` chooses the top 2 chats; their names print.
+5. **Export** — for each of the 2 chats: open chat → menu → Export chat → media option → Drive upload → success.
+6. **Process** — Drive download → archive extraction → transcript files appear.
+7. **Summary** — exit code 0; `~/whatsapp_test/transcripts/` contains 2 transcript files.
+
+**Pass criteria:**
+
+- Exit code 0.
+- `~/whatsapp_test/transcripts/` contains exactly 2 `.txt` files matching the chosen chat names.
+- No traceback in the terminal.
+- No `verify_whatsapp_is_open()` failure messages.
+
+**Teardown:**
+
+- `adb disconnect` (wireless) or unplug USB cable.
+- `rm -rf ~/whatsapp_test` if you don't want to keep the output.
+- Optionally remove the just-exported files from Drive (`WhatsApp Chat with <name>` zips at Drive root).
+
+### `manual-device-tui` *(advisory — never auto-run)*
+
+```yaml
+trigger: []
+tool: manual
+artifacts: []
+pass: human-confirmed per the playbook below
+```
+
+Same preconditions as `manual-device-export`. The difference is that the contributor walks the full Textual TUI by hand to confirm the on-screen flow has not regressed.
+
+**Command:**
+
+```bash
+poetry run whatsapp
+```
+
+**Expected screen-by-screen:**
+
+1. **Connect tab** — `PreflightPanel` is visible at the top with three probe rows; pressing `p` re-runs preflight.
+2. **Connect tab** — selecting the device (USB or wireless) connects; status row updates to `Connected`.
+3. **Discover tab** — chat list populates; count visible bottom-right (~700+).
+4. **Select tab** — checkbox-select 1–2 chats; export button enables.
+5. **Export tab** — progress bars advance; per-chat status updates live.
+6. **Process tab** — pipeline progress visible; transcripts populate.
+7. **Summary tab** — final counts; output path clickable.
+
+**Pass criteria:**
+
+- No traceback in the TUI's footer.
+- All seven steps above are reachable without keyboard fight.
+- The output directory matches what the Summary tab claims.
+
+**Teardown:** quit the TUI with `q`. Same artifact cleanup as `manual-device-export`.
+
+## Escalation
+
+- `terminal` covers every auto-run recipe. No browser tools are needed because there is no web surface in this repo.
+- The two `manual-*` recipes are *advisory only* — they document a human playbook. The dispatcher must never execute them; their empty triggers enforce that.
+- Tests gated by `@pytest.mark.requires_device`, `@pytest.mark.requires_api`, `@pytest.mark.requires_drive`, `@pytest.mark.manual`, and `@pytest.mark.slow` are excluded from every auto-run recipe (`-m "not …"`). They run only on explicit human invocation.
+
+## PR review hook
+
+```bash
+gh pr checkout <N>
+poetry install --with dev
+
+poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --no-cov
+poetry run pytest tests/integration/test_cli.py -q --no-cov
+poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --no-cov
+poetry run whatsapp --help | grep -q -- '--headless' && echo "help ✓"
+
+OUT=$(mktemp -d)
+poetry run whatsapp --pipeline-only sample_data "$OUT" --no-transcribe --no-output-media --skip-drive-download
+find "$OUT/transcripts" -type f -size +0c -name "*.txt" | grep -q . && echo "pipeline-on-fixtures ✓"
+rm -rf "$OUT"
+
+gh pr comment <N> --body "Verification re-run on PR branch: unit-fast ✓ · integration-cli ✓ · integration-tui ✓ · pipeline-on-fixtures ✓"
+```
+
+This script intentionally runs the full host-only suite at PR time (not gated by changed files), because the reviewer wants to know everything still works — not just what was touched.

--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -48,7 +48,6 @@ which whatsapp >/dev/null || { echo "whatsapp not on PATH"; exit 1; }
 trigger:
   - "whatsapp_chat_autoexport/**"
   - "tests/unit/**"
-  - "tests/integration/**"
   - "pyproject.toml"
   - ".claude/testing.md"
 tool: terminal
@@ -59,7 +58,7 @@ pass: exit 0, all collected tests passed
 
 **Steps:**
 
-1. `poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --tb=short --no-cov > assets/verification/<N>/unit-fast/pytest.log 2>&1`
+1. `poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive and not manual" -q --tb=short --no-cov > assets/verification/<N>/unit-fast/pytest.log 2>&1`
 2. Pass iff exit 0.
 
 ### `integration-cli`
@@ -115,7 +114,7 @@ tool: terminal
 artifacts:
   - pipeline.log
   - output-tree.txt
-pass: exit 0 and at least one non-empty file under <out>/transcripts/
+pass: pipeline command exits 0 AND `find <out>/transcripts -type f -size +0c -name "*.txt"` finds ≥1 match
 ```
 
 **Steps:**
@@ -170,7 +169,7 @@ poetry run whatsapp --headless \
 **Pass criteria:**
 
 - Exit code 0.
-- `~/whatsapp_test/transcripts/` contains exactly 2 `.txt` files matching the chosen chat names.
+- `~/whatsapp_test/transcripts/` contains up to 2 `.txt` files matching the chosen chat names (community-incompatible chats are skipped — fewer is allowed; zero indicates a regression).
 - No traceback in the terminal.
 - No `verify_whatsapp_is_open()` failure messages.
 
@@ -227,7 +226,7 @@ poetry run whatsapp
 gh pr checkout <N>
 poetry install --with dev
 
-poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --no-cov
+poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive and not manual" -q --no-cov
 poetry run pytest tests/integration/test_cli.py -q --no-cov
 poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --no-cov
 poetry run whatsapp --help | grep -q -- '--headless' && echo "help ✓"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ EXECUTIVE_SUMMARY.md
 .venv
 *.xml
 .serena
-.claude
 upload_error_*.xml
 
 # Testing
@@ -25,7 +24,13 @@ whatsapp_chat_autoexport.code-workspace
 
 # Log files
 .logs/
-.claude/
+
+# .claude/ is mostly local agent state — only specific files are tracked
+.claude/*
+!.claude/agents/
+!.claude/commands/
+!.claude/testing.md
+
 .mcp.json
 
 # Scratch / one-off scripts

--- a/docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md
+++ b/docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md
@@ -1,0 +1,475 @@
+# Three-tier testing protocol — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current minimal `.claude/testing.md` with a three-tier protocol (unit / integration / manual device-required) that covers both the CLI (`whatsapp --headless`, `--pipeline-only`) and TUI (`whatsapp` Textual app) surfaces, and that drives `/aj-flow flow` Step 9 dispatch sensibly.
+
+**Architecture:** A single markdown file (`.claude/testing.md`) with `version: 1` frontmatter and four sections (Dev rig, Recipes, Escalation, PR review hook). Five recipes total: `unit-fast`, `integration-cli`, `integration-tui`, `pipeline-on-fixtures`, `manual-device-export` (and a sibling `manual-device-tui`). Manual recipes use `trigger: []` so dispatch never auto-runs them; the prose surfaces the playbook to a human reader. No new test infrastructure — every recipe runs against existing pytest tests, the existing `whatsapp` CLI, and the bundled `sample_data/WhatsApp Chat with Example/`.
+
+**Tech Stack:** Markdown (YAML frontmatter), pytest with markers (`unit`, `integration`, `manual`, `requires_device`, `requires_api`, `requires_drive`, `slow`), Textual `pilot`, `whatsapp` Poetry-installed binary.
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `.claude/testing.md` | **rewrite** | The dispatch contract. Replaces existing two-recipe file with five-recipe three-tier protocol. |
+| `docs/superpowers/specs/2026-04-29-define-realistic-testing-protocols-design.md` | already committed | The spec this plan implements. |
+| `docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md` | this file | The plan. |
+| `tests/README.md` | **add one link line** | Cross-reference to `.claude/testing.md` so the two docs don't drift. |
+
+No code files are touched. No `verify.sh` is added. No new pytest config.
+
+---
+
+## Task 1: Rewrite `.claude/testing.md`
+
+**Files:**
+- Modify: `.claude/testing.md` (full rewrite)
+
+- [ ] **Step 1: Replace the file content with the three-tier protocol**
+
+Write this exact content to `.claude/testing.md`:
+
+````markdown
+---
+version: 1
+---
+
+# Testing — WhatsApp Chat AutoExport
+
+Read by `/aj-flow flow` Step 9 (Verify) and `/aj-flow review` Step 5 (Re-verify).
+See `aj-flow/PREFERENCES.md` → "Per-project testing conventions" for the contract.
+
+For human-friendly running instructions, see [`tests/README.md`](../tests/README.md).
+
+## Tiers — what each one is for
+
+| Tier | Where | Time budget | Catches | Doesn't catch |
+|---|---|---|---|---|
+| **Unit** | `tests/unit/` | ~30s focused, ~3min full | Logic regressions, mode dispatch, parsers, output builders. Mocks device + Drive + transcription. | Real Appium / Drive / API behaviour, real Textual UI rendering. |
+| **Integration (host-only)** | `tests/integration/` | ~1–2min | Textual `pilot` screen flow, CLI subprocess wiring, multi-component plumbing. Still mocks device + Drive + transcription. | Real device interaction, real upload, real transcription provider. |
+| **Manual (device-required)** | `tests/manual/` + the playbook below | 5–15min per pass | Appium UI scraping fragility, wireless-ADB pairing, real WhatsApp UI changes, Drive upload, `verify_whatsapp_is_open()` safety. | Anything not in the playbook (community chats, locked phone, expired pairing codes — documented as known limits). |
+
+## Surface coverage
+
+| Surface | Unit | Integration | Manual |
+|---|---|---|---|
+| **CLI** | `tests/unit/test_cli_entry.py`, `test_headless.py`, `test_pipeline_only.py`, `test_deprecated_entry.py` | `tests/integration/test_cli.py` + `whatsapp --help` smoke | `manual-device-export` |
+| **TUI** | `tests/unit/test_main_screen.py`, `test_connect_pane.py`, `test_export_pane.py`, … | `tests/integration/test_textual_tui.py`, `test_tab_navigation.py`, `test_connect_pane_preflight.py` | `manual-device-tui` |
+
+## Dev rig
+
+**Make available on PATH:**
+
+```bash
+poetry install --with dev
+```
+
+**Smoke-check binary is reachable:**
+
+```bash
+which whatsapp >/dev/null || { echo "whatsapp not on PATH"; exit 1; }
+```
+
+**Tear down:** nothing — no long-running services. The Textual pilot tests spin up the TUI in-process and tear it down per-test.
+
+## Recipes
+
+### `unit-fast`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/**"
+  - "tests/unit/**"
+  - "tests/integration/**"
+  - "pyproject.toml"
+  - ".claude/testing.md"
+tool: terminal
+artifacts:
+  - pytest.log
+pass: exit 0, all collected tests passed
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --tb=short --no-cov > assets/verification/<N>/unit-fast/pytest.log 2>&1`
+2. Pass iff exit 0.
+
+### `integration-cli`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/cli_entry.py"
+  - "whatsapp_chat_autoexport/headless.py"
+  - "whatsapp_chat_autoexport/pipeline.py"
+  - "whatsapp_chat_autoexport/deprecated_entry.py"
+  - "tests/integration/test_cli.py"
+tool: terminal
+artifacts:
+  - pytest.log
+  - help.log
+pass: exit 0 and `--headless` appears in help output
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/integration/test_cli.py -q --tb=short --no-cov > assets/verification/<N>/integration-cli/pytest.log 2>&1`
+2. `poetry run whatsapp --help > assets/verification/<N>/integration-cli/help.log 2>&1`
+3. Pass iff (1) exit 0 and `grep -q -- '--headless' assets/verification/<N>/integration-cli/help.log`.
+
+### `integration-tui`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/tui/**"
+  - "tests/integration/test_textual_tui.py"
+  - "tests/integration/test_tab_navigation.py"
+  - "tests/integration/test_connect_pane_preflight.py"
+tool: terminal
+artifacts:
+  - pytest.log
+pass: exit 0
+```
+
+**Steps:**
+
+1. `poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --tb=short --no-cov > assets/verification/<N>/integration-tui/pytest.log 2>&1`
+2. Pass iff exit 0.
+
+### `pipeline-on-fixtures`
+
+```yaml
+trigger:
+  - "whatsapp_chat_autoexport/pipeline.py"
+  - "whatsapp_chat_autoexport/output/**"
+  - "whatsapp_chat_autoexport/export/archive_extractor.py"
+  - "whatsapp_chat_autoexport/transcription/**"
+tool: terminal
+artifacts:
+  - pipeline.log
+  - output-tree.txt
+pass: exit 0 and at least one non-empty file under <out>/transcripts/
+```
+
+**Steps:**
+
+1. Create a temp output dir under the verification artifacts root:
+   `OUT=assets/verification/<N>/pipeline-on-fixtures/out && mkdir -p "$OUT"`
+2. `poetry run whatsapp --pipeline-only sample_data "$OUT" --no-transcribe --no-output-media --skip-drive-download > assets/verification/<N>/pipeline-on-fixtures/pipeline.log 2>&1`
+3. `find "$OUT" > assets/verification/<N>/pipeline-on-fixtures/output-tree.txt`
+4. Pass iff (2) exit 0 and `find "$OUT/transcripts" -type f -size +0c -name "*.txt" | grep -q .`.
+
+### `manual-device-export` *(advisory — never auto-run)*
+
+```yaml
+trigger: []
+tool: manual
+artifacts: []
+pass: human-confirmed per the playbook below
+```
+
+**Why empty triggers:** the dispatcher only auto-runs recipes whose triggers match changed files. An empty trigger list guarantees this recipe is never auto-fired. The recipe exists so the doc surfaces the playbook in a single place; a contributor changing `export/`, `google_drive/`, or anything in the Appium path **must** read this and run it by hand.
+
+**Preconditions** (all required):
+
+- Phone unlocked, screen on, kept awake during the run.
+- WhatsApp installed and signed in on the phone.
+- USB debugging *or* wireless debugging paired with this Mac (`adb devices` shows the device).
+- Appium installed (`npm install -g appium`) and reachable on port 4723.
+- `OPENAI_API_KEY` *or* `ELEVENLABS_API_KEY` exported in the shell.
+- Google Drive signed in on the device.
+- Expected chat-list count ≈ 700+ (confirms WhatsApp UI is healthy on the device).
+
+**Command** (limited 2-chat smoke):
+
+```bash
+poetry run whatsapp --headless \
+  --output ~/whatsapp_test \
+  --auto-select \
+  --limit 2 \
+  --no-output-media
+```
+
+**Expected screen-by-screen** (terminal output highlights):
+
+1. **Preflight** — three probe lines (Whisper / ElevenLabs / Drive); none HARD FAIL.
+2. **Connect** — Appium starts; `WhatsApp connected` appears; `verify_whatsapp_is_open()` reports OK.
+3. **Discover** — chat-list collection runs (logs show pass 1, pass 2, ContactsContract reconciliation).
+4. **Select** — `--auto-select --limit 2` chooses the top 2 chats; their names print.
+5. **Export** — for each of the 2 chats: open chat → menu → Export chat → media option → Drive upload → success.
+6. **Process** — Drive download → archive extraction → transcript files appear.
+7. **Summary** — exit code 0; `~/whatsapp_test/transcripts/` contains 2 transcript files.
+
+**Pass criteria:**
+
+- Exit code 0.
+- `~/whatsapp_test/transcripts/` contains exactly 2 `.txt` files matching the chosen chat names.
+- No traceback in the terminal.
+- No `verify_whatsapp_is_open()` failure messages.
+
+**Teardown:**
+
+- `adb disconnect` (wireless) or unplug USB cable.
+- `rm -rf ~/whatsapp_test` if you don't want to keep the output.
+- Optionally remove the just-exported files from Drive (`WhatsApp Chat with <name>` zips at Drive root).
+
+### `manual-device-tui` *(advisory — never auto-run)*
+
+```yaml
+trigger: []
+tool: manual
+artifacts: []
+pass: human-confirmed per the playbook below
+```
+
+Same preconditions as `manual-device-export`. The difference is that the contributor walks the full Textual TUI by hand to confirm the on-screen flow has not regressed.
+
+**Command:**
+
+```bash
+poetry run whatsapp
+```
+
+**Expected screen-by-screen:**
+
+1. **Connect tab** — `PreflightPanel` is visible at the top with three probe rows; pressing `p` re-runs preflight.
+2. **Connect tab** — selecting the device (USB or wireless) connects; status row updates to `Connected`.
+3. **Discover tab** — chat list populates; count visible bottom-right (~700+).
+4. **Select tab** — checkbox-select 1–2 chats; export button enables.
+5. **Export tab** — progress bars advance; per-chat status updates live.
+6. **Process tab** — pipeline progress visible; transcripts populate.
+7. **Summary tab** — final counts; output path clickable.
+
+**Pass criteria:**
+
+- No traceback in the TUI's footer.
+- All seven steps above are reachable without keyboard fight.
+- The output directory matches what the Summary tab claims.
+
+**Teardown:** quit the TUI with `q`. Same artifact cleanup as `manual-device-export`.
+
+## Escalation
+
+- `terminal` covers every auto-run recipe. No browser tools are needed because there is no web surface in this repo.
+- The two `manual-*` recipes are *advisory only* — they document a human playbook. The dispatcher must never execute them; their empty triggers enforce that.
+- Tests gated by `@pytest.mark.requires_device`, `@pytest.mark.requires_api`, `@pytest.mark.requires_drive`, `@pytest.mark.manual`, and `@pytest.mark.slow` are excluded from every auto-run recipe (`-m "not …"`). They run only on explicit human invocation.
+
+## PR review hook
+
+```bash
+gh pr checkout <N>
+poetry install --with dev
+
+poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --no-cov
+poetry run pytest tests/integration/test_cli.py -q --no-cov
+poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --no-cov
+poetry run whatsapp --help | grep -q -- '--headless' && echo "help ✓"
+
+OUT=$(mktemp -d)
+poetry run whatsapp --pipeline-only sample_data "$OUT" --no-transcribe --no-output-media --skip-drive-download
+find "$OUT/transcripts" -type f -size +0c -name "*.txt" | grep -q . && echo "pipeline-on-fixtures ✓"
+rm -rf "$OUT"
+
+gh pr comment <N> --body "Verification re-run on PR branch: unit-fast ✓ · integration-cli ✓ · integration-tui ✓ · pipeline-on-fixtures ✓"
+```
+
+This script intentionally runs the full host-only suite at PR time (not gated by changed files), because the reviewer wants to know everything still works — not just what was touched.
+````
+
+- [ ] **Step 2: Run the existing test suites against the new file**
+
+The doc itself is not executable, but the recipes it declares must work end-to-end. Run each auto-run recipe **once, by hand**, capturing its log into the verification artifact directory expected by `flow` Step 9:
+
+```bash
+N=21
+mkdir -p assets/verification/$N/{unit-fast,integration-cli,integration-tui,pipeline-on-fixtures}
+
+# unit-fast
+poetry run pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive" -q --tb=short --no-cov \
+  > assets/verification/$N/unit-fast/pytest.log 2>&1
+echo "unit-fast exit: $?"
+
+# integration-cli
+poetry run pytest tests/integration/test_cli.py -q --tb=short --no-cov \
+  > assets/verification/$N/integration-cli/pytest.log 2>&1
+echo "integration-cli pytest exit: $?"
+poetry run whatsapp --help > assets/verification/$N/integration-cli/help.log 2>&1
+grep -q -- '--headless' assets/verification/$N/integration-cli/help.log && echo "help ✓"
+
+# integration-tui
+poetry run pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py -q --tb=short --no-cov \
+  > assets/verification/$N/integration-tui/pytest.log 2>&1
+echo "integration-tui exit: $?"
+
+# pipeline-on-fixtures
+OUT=assets/verification/$N/pipeline-on-fixtures/out
+mkdir -p "$OUT"
+poetry run whatsapp --pipeline-only sample_data "$OUT" --no-transcribe --no-output-media --skip-drive-download \
+  > assets/verification/$N/pipeline-on-fixtures/pipeline.log 2>&1
+echo "pipeline-on-fixtures exit: $?"
+find "$OUT" > assets/verification/$N/pipeline-on-fixtures/output-tree.txt
+find "$OUT/transcripts" -type f -size +0c -name "*.txt" | grep -q . && echo "transcripts ✓"
+```
+
+Expected: every recipe exits 0. If any recipe fails, fix the recipe definition (paths, flags) **before** committing — the doc is the contract; a failing recipe is a doc bug.
+
+- [ ] **Step 3: Verify the trigger globs would match this PR's diff**
+
+A quick sanity check that `flow` Step 9's dispatcher (when it runs against this PR) would fire `unit-fast` (the only recipe whose triggers match a change to `.claude/testing.md`):
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected output (subset of):
+
+```
+.claude/testing.md
+docs/superpowers/specs/2026-04-29-define-realistic-testing-protocols-design.md
+docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md
+tests/README.md
+```
+
+`unit-fast` lists `.claude/testing.md` in its triggers, so dispatch will pick it up. The other two recipes (`integration-cli`, `integration-tui`, `pipeline-on-fixtures`) won't match — that is correct, because this PR doesn't touch CLI, TUI, or pipeline source. Document this expectation in the commit message of Step 5.
+
+- [ ] **Step 4: Stage and commit the rewrite**
+
+```bash
+git add .claude/testing.md
+git commit -m "docs(testing): three-tier protocol with five recipes (#21)
+
+Replaces the previous two-recipe minimal contract with three tiers
+(unit / integration / manual device-required) and five recipes:
+unit-fast, integration-cli, integration-tui, pipeline-on-fixtures,
+manual-device-export, manual-device-tui.
+
+Manual recipes use trigger: [] so dispatch never auto-runs them; the
+prose surfaces the playbook for a human reader. Both CLI and TUI
+surfaces are addressed by at least one recipe per applicable tier.
+
+PR review hook runs the full host-only suite (not diff-gated) so a
+reviewer sees everything is green at PR time.
+
+Closes #21"
+```
+
+---
+
+## Task 2: Cross-reference link from `tests/README.md`
+
+**Files:**
+- Modify: `tests/README.md` (one line near the top, after the H1)
+
+- [ ] **Step 1: Read the current top of `tests/README.md`**
+
+Run: `head -10 tests/README.md`
+
+Expected: file starts with `# Testing Guide` and a one-paragraph intro.
+
+- [ ] **Step 2: Insert the cross-reference under the H1**
+
+Use the Edit tool to insert this line immediately after `# Testing Guide`:
+
+```markdown
+
+> **For the agentic dispatch contract used by `/aj-flow flow` Step 9, see [`.claude/testing.md`](../.claude/testing.md).**
+```
+
+The Edit replaces the first H1 + immediately following blank line block with the H1 + blockquote + blank line, leaving the rest of the file untouched.
+
+- [ ] **Step 3: Confirm the file still parses sensibly**
+
+Run: `head -5 tests/README.md`
+
+Expected: H1 followed by the new blockquote, then the original intro paragraph.
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+git add tests/README.md
+git commit -m "docs(tests): link tests/README.md to .claude/testing.md (#21)
+
+Keeps the human-friendly running guide and the agent dispatch contract
+cross-referenced so they don't drift."
+```
+
+---
+
+## Task 3: Capture verification artifacts for the PR body
+
+**Files:**
+- Read-only — uses `assets/verification/21/` produced by Task 1 Step 2.
+
+- [ ] **Step 1: Confirm artifacts exist**
+
+Run:
+
+```bash
+ls -la assets/verification/21/
+ls -la assets/verification/21/unit-fast/
+ls -la assets/verification/21/integration-cli/
+ls -la assets/verification/21/integration-tui/
+ls -la assets/verification/21/pipeline-on-fixtures/
+```
+
+Expected: each directory contains the logs listed in the recipe `artifacts:` blocks (`pytest.log`, `help.log`, `pipeline.log`, `output-tree.txt`).
+
+- [ ] **Step 2: Confirm `assets/verification/` is gitignored**
+
+Run: `git check-ignore -v assets/verification/21/unit-fast/pytest.log`
+
+Expected: a line like `.gitignore:N:assets/verification/    assets/verification/21/unit-fast/pytest.log` confirming the path is ignored.
+
+If the file is **not** ignored (no output from `git check-ignore`), append `assets/verification/` to `.gitignore` and commit:
+
+```bash
+echo "assets/verification/" >> .gitignore
+git add .gitignore
+git commit -m "chore: ignore assets/verification/ (aj-flow trail)"
+```
+
+(Likely no-op — `aj-flow bootstrap`'s previous run already added this. Check first.)
+
+- [ ] **Step 3: Append a one-line summary to `flow.log`**
+
+```bash
+echo "$(date '+%H:%M:%S') step 8/9 done — unit-fast ✓ · integration-cli ✓ · integration-tui ✓ · pipeline-on-fixtures ✓" \
+  >> assets/verification/21/flow.log
+```
+
+This is the entry that the PR body's `## Agent ran` section points to.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| §4 Tiers | Task 1 — "Tiers" table in the new doc |
+| §5 Surface coverage | Task 1 — "Surface coverage" table |
+| §6 Recipes (5 of them) | Task 1 — five recipe blocks |
+| §7 Manual playbook fields | Task 1 — `manual-device-export` and `manual-device-tui` recipe blocks |
+| §8 PR review hook | Task 1 — `## PR review hook` section |
+| §9 DoD: file with frontmatter + 4 sections | Task 1 |
+| §9 DoD: three tiers covered | Task 1 — five recipes split across three tiers |
+| §9 DoD: CLI + TUI per applicable tier | Task 1 — surface-coverage table + recipe triggers |
+| §9 DoD: dispatch picks up matching recipes | Task 1 Step 3 — diff vs `unit-fast` triggers |
+| §10 Risk: glob mismatch | `unit-fast` has broad triggers including `.claude/testing.md` |
+| §10 Open question on `tool: manual` | Resolved with `trigger: []` convention; documented in the recipe block + Escalation section |
+| §11 `tests/README.md` link | Task 2 |
+
+**Placeholder scan:** none. Every recipe has full YAML, full steps, and exact pass criteria. Every command has explicit paths and expected outputs.
+
+**Type consistency:** recipe names are spelled identically in the doc, the verification commands, and the PR review hook (`unit-fast`, `integration-cli`, `integration-tui`, `pipeline-on-fixtures`, `manual-device-export`, `manual-device-tui`). The artifact directory names match the recipe names.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md`.
+
+This plan is small (3 tasks, all doc + verification) so **inline execution via `superpowers:executing-plans`** is more appropriate than spinning up a subagent per task. The flow Step 6 dispatcher should pick `executing-plans`, not `subagent-driven-development`, for this size of change.

--- a/docs/superpowers/specs/2026-04-29-define-realistic-testing-protocols-design.md
+++ b/docs/superpowers/specs/2026-04-29-define-realistic-testing-protocols-design.md
@@ -1,0 +1,106 @@
+# Spec — Three-tier testing protocol (`.claude/testing.md`)
+
+**Issue:** [#21](https://github.com/ajanderson1/whatsapp_chat_autoexport/issues/21) — Define realistic testing protocols across unit, integration, and manual tiers
+**Date:** 2026-04-29
+**Branch:** `docs/21-define-realistic-testing-protocols`
+**Mode:** `--auto`
+
+---
+
+## 1. Problem
+
+The repo has three real testing tiers but no single document that says **which tier catches what, when each tier runs, or what the manual playbook is** for the device-required scenarios. The current `.claude/testing.md` is minimal (two recipes: `unit-tests`, `help-flag`) and does not surface:
+
+- The real split between `tests/unit/`, `tests/integration/`, and `tests/manual/`.
+- That **TUI integration** (Textual pilot) is part of `tests/integration/test_textual_tui.py` and worth its own targeted recipe so a TUI-only diff exercises it cleanly.
+- The fact that the **CLI surface is exercised in two places** — fast `tests/unit/test_cli_entry.py` (mode dispatch) and slower `tests/integration/test_cli.py` (subprocess) — and what each tier actually proves.
+- The **device-required** Appium playbook (phone unlocked, wireless ADB paired, Appium running) which is intentionally never run in CI (gated by `requires_device`).
+- The escalation rule from terminal → `claude-in-chrome` (already declared in `aj-flow/PREFERENCES.md`) and where it might bite us here (it doesn't, today — and the doc should say so).
+
+The DoD lists four conditions; this spec satisfies all four.
+
+## 2. Goal
+
+Codify the three tiers in one place so:
+
+- A contributor reading the file knows **what to run before claiming a change is safe**, in less than two minutes.
+- `/aj-flow flow` Step 9 (Verify) and `/aj-flow review` Step 5 (Re-verify) both pick up the *right* recipes for whatever was changed — not "all tests" and not "nothing".
+- Manual device-required runs have an explicit playbook (preconditions, command, expected screen-by-screen outcomes, teardown) that is **executable from the doc alone** without grepping CLAUDE.md.
+
+## 3. Non-goals
+
+- **No new test infrastructure.** No new pytest plugins, no new GHA workflows, no playwright. Document protocols against what already exists (pytest, Textual pilot, `sample_data/WhatsApp Chat with Example/`, `requires_device` marker).
+- **No CI changes.** Manual recipes stay manual; the `requires_device` marker already excludes them from CI by convention. We don't add a `pytest -m manual` step to GHA.
+- **No replacement of `tests/README.md`.** That file is for humans reading the repo; `.claude/testing.md` is for the dispatch contract. They link at each other but live separately.
+- **No new sample fixtures.** The existing `sample_data/WhatsApp Chat with Example/` (3,151 messages, 191 media files) is sufficient for every recipe except `manual-device-export`.
+
+## 4. Tiers — what each one is for
+
+| Tier | Where | Time budget | Catches | Doesn't catch |
+|---|---|---|---|---|
+| **Unit** | `tests/unit/` | < 30s for a focused subset, ~3min for full suite | Logic bugs, regression in pure functions, mode dispatch, parsers, output builders. Mocks the whole device + Drive + transcription stack. | Anything involving Appium, Drive, real APIs, or the Textual UI rendering correctly under user input. |
+| **Integration (host-only)** | `tests/integration/` | ~1–2min | TUI screen flow under Textual `pilot`, CLI subprocess argument parsing, multi-component wiring. Still mocks device + Drive + transcription. | The actual Appium ↔ WhatsApp interaction; the actual Drive upload; the actual transcription provider response. |
+| **Manual (device-required)** | `tests/manual/` + a written playbook | 5–15min per pass | Appium UI scraping fragility, wireless-ADB pairing, real WhatsApp UI changes, Drive upload mechanics, `verify_whatsapp_is_open()` safety logic. | Anything not exercised in the playbook (community chats, locked phone, expired pairing codes — those are documented as known limits, not retested each time). |
+
+## 5. Surface coverage
+
+Both **CLI** and **TUI** must have at least one recipe per *applicable* tier:
+
+| Surface | Unit | Integration | Manual |
+|---|---|---|---|
+| **CLI** (`whatsapp --headless`, `--pipeline-only`) | `tests/unit/test_cli_entry.py`, `test_headless.py`, `test_pipeline_only.py`, `test_deprecated_entry.py` (≈82 tests) | `tests/integration/test_cli.py` (subprocess + `--help`) | `manual-device-export` playbook (real phone, headless mode) |
+| **TUI** (`whatsapp` Textual app) | `tests/unit/test_main_screen.py`, `test_connect_pane.py`, `test_export_pane.py`, etc. (TUI-specific unit tests with Textual mocks) | `tests/integration/test_textual_tui.py` (Textual pilot, ~28 tests) | `manual-device-tui` playbook (real phone, full TUI walkthrough) |
+
+"*Applicable*" means: the manual tier is required for both, but the unit/integration recipes are not split per surface — they share triggers via path globs. A change touching only TUI files runs the TUI recipes; a CLI-only diff runs CLI recipes; a touch to anything in `whatsapp_chat_autoexport/` runs the broad unit-suite recipe.
+
+## 6. Recipes — names and intent
+
+The `recipes` section will define **five** recipes (replacing today's two):
+
+1. **`unit-fast`** — `pytest tests/unit/ -m "not slow and not requires_api and not requires_device and not requires_drive"`. Triggers on any source file or test file. Time budget: ~1min.
+2. **`integration-cli`** — `pytest tests/integration/test_cli.py` plus a `whatsapp --help` smoke. Triggers on `cli_entry.py`, `headless.py`, `pipeline.py`. Time budget: ~30s.
+3. **`integration-tui`** — `pytest tests/integration/test_textual_tui.py tests/integration/test_tab_navigation.py tests/integration/test_connect_pane_preflight.py`. Triggers on `tui/**`. Time budget: ~1min.
+4. **`pipeline-on-fixtures`** — `whatsapp --pipeline-only sample_data/ <tmp>/ --no-transcribe --no-output-media`, asserts a non-empty transcript appears at `<tmp>/transcripts/`. Triggers on `pipeline.py`, `output/**`, `export/archive_extractor.py`, `transcription/**`. Time budget: ~10s. Proves the pipeline-only mode works end-to-end against the bundled real export.
+5. **`manual-device-export`** *(declared but not auto-run)* — recipe with `tool: manual` to flag itself as a human playbook. Trigger globs: `export/**`, `google_drive/**`, anything that touches Appium/ADB. Steps are written for a human; the recipe's "pass" line documents what success looks like (e.g., "≥1 chat exported and visible in `<output>/transcripts/`"). The dispatch logic prints the playbook to stdout instead of executing it, so a contributor sees: *"This change requires a manual device run. Steps follow:"* and never has a green tick they didn't earn.
+
+## 7. Manual playbook — what it must contain
+
+The `manual-device-export` recipe (and a sibling `manual-device-tui` for the TUI surface) embeds an executable-by-human checklist with these required fields:
+
+- **Preconditions** — phone unlocked; USB debugging or wireless debugging paired; Appium reachable; `OPENAI_API_KEY` *or* `ELEVENLABS_API_KEY` exported; Google Drive signed in on the device; chat-list count expected (~700+).
+- **Command** — exact one-liner (`poetry run whatsapp --headless --output ~/whatsapp_test --auto-select --limit 2 --no-output-media`) so the contributor can copy-paste.
+- **Expected screen-by-screen** — what should appear in the terminal at each phase (preflight → connect → discover → select → export → process → summary). Bullet-pointed; not full output.
+- **Teardown** — disconnect ADB, delete `~/whatsapp_test`, optionally remove from Drive.
+- **Pass criteria** — exact files that must exist at the end.
+
+The playbook lives **inside** `.claude/testing.md` (not a separate file) so the dispatch contract and the prose-for-humans stay together — a contributor reading the doc sees both at once.
+
+## 8. PR review hook
+
+The `## PR review hook` section is **what a reviewer (or `/aj-flow review` Step 5) re-runs against the PR branch**. It must:
+
+- Match the recipes — same `unit-fast` + `integration-cli` + `integration-tui` + `pipeline-on-fixtures` invocations, run unconditionally (not gated by changed files, because at PR time you want the full host-only suite green).
+- Skip manual recipes (the reviewer doesn't run a phone test on a glance review).
+- Post a single `gh pr comment` summarising which recipes passed, mirroring the existing pattern.
+
+## 9. Definition of done — restated
+
+| DoD item | How this spec satisfies it |
+|---|---|
+| `.claude/testing.md` exists with `version: 1` frontmatter and the four required sections | Existing file is overwritten with new content; frontmatter preserved; sections: Dev rig (= Dev server), Recipes, Escalation, PR review hook |
+| Recipes cover three tiers | `unit-fast` (unit) · `integration-cli` + `integration-tui` + `pipeline-on-fixtures` (integration) · `manual-device-export` + `manual-device-tui` (manual) |
+| CLI and TUI surfaces each addressed by ≥1 recipe per applicable tier | See §5 surface-coverage matrix |
+| `/aj-flow flow` Step 9 dispatch picks up matching recipes | Verified in this branch's own Step 9: a no-op diff to `cli_entry.py` (e.g., a single-line comment touch in a throwaway test branch — *not* in this PR) would fire `unit-fast` + `integration-cli` + `pipeline-on-fixtures`. **In-flow proof:** the change in this PR (only `.claude/testing.md` and `docs/superpowers/**`) intentionally does *not* match any recipe trigger except via a special trigger pattern we add: the testing-doc itself triggers `unit-fast` so doc edits don't ship without at least running the unit suite. This is the smallest credible proof that dispatch fires. |
+
+## 10. Risks and assumptions
+
+- **Risk:** A trigger-glob mismatch silently skips a recipe. *Mitigation:* the `unit-fast` recipe has a broad trigger (`whatsapp_chat_autoexport/**`, `tests/**`, `pyproject.toml`, `.claude/testing.md`) so almost any meaningful change fires it.
+- **Risk:** `pipeline-on-fixtures` is sensitive to changes in the bundled `sample_data/` content. *Mitigation:* assertions are minimal (transcript file exists, non-empty) — not byte-exact.
+- **Assumption:** `tools: manual` is recognised as "print the playbook, don't try to execute it" by the flow Step 9 dispatcher. **Open question for plan:** the dispatcher currently only handles `tool: terminal`. The plan must specify whether to (a) add `tool: manual` handling to the skill, or (b) document `manual-*` recipes as advisory-only inside `.claude/testing.md` — relying on naming to keep dispatch from auto-running them. **Recommended:** option (b), since changing the skill is out of scope for this issue. The recipe trigger is left empty (`trigger: []`) so dispatch never matches it; the prose surfaces the playbook to a human reader.
+- **Assumption:** No `verify.sh` exists at the repo root and we don't add one — the `.claude/testing.md` path is the contract from now on.
+
+## 11. Out-of-band notes for the human reviewer
+
+- The existing `tests/README.md` is left untouched. A short link added at the top of `.claude/testing.md` ("For human-friendly running instructions, see `tests/README.md`") keeps the two docs from drifting.
+- `manual-*` recipes use `trigger: []` (empty list). This is the explicit signal "this recipe is advisory; never auto-run." The plan will codify this convention in the doc itself so future readers don't wonder.
+- The retry budget (1) and safety-stop semantics described in `aj-flow/PREFERENCES.md` are unchanged — `.claude/testing.md` only adds recipe definitions, not new flow semantics.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,7 @@
 # Testing Guide
 
+> **For the agentic dispatch contract used by `/aj-flow flow` Step 9, see [`.claude/testing.md`](../.claude/testing.md).**
+
 This directory contains the test suite for the WhatsApp Chat Auto-Export project using **pytest**.
 
 ## Directory Structure


### PR DESCRIPTION
## Summary

- Replace minimal `.claude/testing.md` (2 recipes) with a three-tier protocol — **unit / integration / manual device-required** — defining five recipes that drive `/aj-flow flow` Step 9 dispatch.
- Both **CLI** (`whatsapp --headless`, `--pipeline-only`) and **TUI** (`whatsapp` Textual app) surfaces have at least one recipe per applicable tier; the surface-coverage matrix is in the doc.
- Manual recipes (`manual-device-export`, `manual-device-tui`) use `trigger: []` so dispatch never auto-runs them; their playbooks are advisory but live in the same doc so a contributor changing Appium/Drive code finds them in one place.

Closes #21

## Agent ran

- [x] Spec: `docs/superpowers/specs/2026-04-29-define-realistic-testing-protocols-design.md`
- [x] Plan: `docs/superpowers/plans/2026-04-29-define-realistic-testing-protocols.md`
- [x] Pre-flight CI: `integration-cli` ✓ · `integration-tui` ✓ · `unit-fast` and `pipeline-on-fixtures` hit a **pre-existing `SpecFormatter` regression on main** (`output_builder.py:56`, missing `contact_name` arg) — same failures reproduce on `main`, **not introduced by this PR**. User explicitly approved skipping and proceeding (logged in `flow.log`).
- [x] Verification (Step 9 dispatch): diff matches `unit-fast` trigger (`.claude/testing.md` is in the trigger list); other recipes correctly skipped (no source changes); manual recipes never auto-run.
- [x] Self-review: PASS-with-nits — 4 of 7 findings applied (commit `d238639`), 3 declined with reasoning logged. Detail in `assets/verification/21/review-1.md`.
- [x] Trail: `assets/verification/21/flow.log` (gitignored — local to the worktree).

## Human should eyeball

- [ ] **`SpecFormatter` regression on main** — out of scope for this issue but should be filed as a follow-up. 29 unit tests + the `pipeline-on-fixtures` end-to-end recipe blocked by it.
- [ ] `.gitignore` reshape: changed from "ignore all of `.claude/`" → "ignore `.claude/*` but keep `agents/`, `commands/`, `testing.md` tracked." Existing tracked files unaffected (verified via `git ls-files .claude/`).
- [ ] Recipe trigger globs match what they should: `unit-fast` (broad), `integration-cli` (cli_entry/headless/pipeline/deprecated_entry), `integration-tui` (tui/**), `pipeline-on-fixtures` (pipeline/output/extractor/transcription).
- [ ] Manual playbook completeness — `manual-device-export` and `manual-device-tui` carry the five required fields (preconditions, command, expected screen-by-screen, pass criteria, teardown).
- [ ] Diff doesn't contain anything surprising.
- [ ] Merge when happy.

## Mode

`--auto`

## DoD coverage (issue #21)

| DoD item | Status |
|---|---|
| `.claude/testing.md` exists with `version: 1` frontmatter and four required sections | ✅ |
| Recipes cover three tiers (unit / integration / manual device-required) | ✅ — five recipes split across the tiers |
| CLI and TUI surfaces each addressed by ≥1 recipe per applicable tier | ✅ — surface-coverage matrix in the doc |
| `/aj-flow flow` Step 9 dispatch picks up matching recipes | ✅ — `.claude/testing.md` is in `unit-fast`'s trigger list, so this very PR's diff would fire `unit-fast` and nothing else |