### PR TITLE
fix: relax verify_whatsapp_is_open for WhatsApp 2.26 Material 3 (#27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,12 +381,12 @@ poetry run whatsapp --pipeline-only /downloads /output --force-transcribe
    - Manages WhatsApp connection and navigation
    - **CRITICAL SAFETY**: Includes robust WhatsApp verification to prevent accidental system UI interaction
    - Key methods:
-     - `verify_whatsapp_is_open()`: **CRITICAL** - Comprehensive verification that WhatsApp is accessible before ANY UI interaction. Checks:
+     - `verify_whatsapp_is_open()`: **CRITICAL** - Verification that WhatsApp is the foregrounded app before ANY UI interaction. Checks:
        - Current package is com.whatsapp (not system settings or other apps)
        - Current activity is safe (not lock screen, system UI, or settings)
-       - WhatsApp UI elements are actually visible and accessible
        - Phone is not locked
        - Called automatically by `connect()`, `interactive_mode()`, and before each export
+       - **Note (#27):** the legacy resource-ID probe was removed — package + activity + lock-check are sufficient and resilient to WhatsApp UI redesigns.
      - `check_if_phone_locked()`: Detects if phone is locked by checking activity, package, and UI elements
      - `detect_phone_lock_state()`: User-friendly wrapper that provides clear error messages if phone is locked
      - `find_element()` / `find_elements()`: Locate UI elements by resource ID, text, or accessibility ID
@@ -470,8 +470,8 @@ poetry run whatsapp --pipeline-only /downloads /output --force-transcribe
    - **Verification checks**:
      - Current package is exactly `com.whatsapp` (not system settings or other apps)
      - Current activity is safe (not lock screen, system UI, or settings)
-     - WhatsApp UI elements (toolbar, action bar, chat list) are actually visible and accessible
      - Phone is not locked (via multiple lock detection strategies)
+     - **Cascade-halt (#27):** if `verify_whatsapp_is_open()` returns False three times in a row, the batch halts via `MAX_CONSECUTIVE_VERIFY_FAILURES = 3` to prevent a regressed verifier from poisoning the entire batch.
    - **Fail-fast behavior**: Script immediately exits with detailed error message if verification fails
    - **Action required**: Phone must be unlocked before running the script and remain unlocked throughout execution
 

--- a/docs/superpowers/plans/2026-04-30-relax-verify-whatsapp-is-open.md
+++ b/docs/superpowers/plans/2026-04-30-relax-verify-whatsapp-is-open.md
@@ -1,0 +1,622 @@
+# Relax `verify_whatsapp_is_open()` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `verify_whatsapp_is_open()` work on WhatsApp 2.26 Material 3 by deleting the legacy resource-ID probe (Check 3), and add a cascade-halt counter so a future verifier regression cannot poison more than 3 chats in a batch.
+
+**Architecture:** Two narrow production edits (`whatsapp_driver.py`, `chat_exporter.py`) plus one new unit test file per edit. TDD throughout — every behaviour change has a failing test before code lands. Existing test suite must still pass with no modifications.
+
+**Tech Stack:** Python 3.13, pytest, unittest.mock. No Appium dependency in tests — drivers are mocked.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-relax-verify-whatsapp-is-open-design.md`
+
+**Issue:** [#27](https://github.com/ajanderson1/whatsapp_chat_autoexport/issues/27)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `whatsapp_chat_autoexport/export/whatsapp_driver.py` | Modify (lines 1272-1329 deleted) | Verifier without legacy resource-ID probe |
+| `whatsapp_chat_autoexport/export/chat_exporter.py` | Modify (5 sites) | Add `MAX_CONSECUTIVE_VERIFY_FAILURES`, counter, helper, two wired call sites, two reset sites |
+| `tests/unit/test_whatsapp_driver_verify.py` | Create | Unit tests for verifier (4 tests) |
+| `tests/unit/test_chat_exporter_verify_cascade.py` | Create | Unit test for cascade-halt (1 test) |
+
+The plan is sequenced so test files land first, then prod code, then refactor. Five tasks total.
+
+---
+
+## Task 1: Pin verifier behaviour with failing tests
+
+**Files:**
+- Create: `tests/unit/test_whatsapp_driver_verify.py`
+- Reference: `whatsapp_chat_autoexport/export/whatsapp_driver.py:1211-1359`
+
+The current verifier hard-fails on Material 3 because Check 3 finds no legacy IDs. We're going to delete Check 3, so we need tests that pin: (a) verifier passes when package + activity are safe and phone unlocked, even if no element-IDs match (this currently FAILS — it's the bug); (b) verifier still fails when package is wrong, activity is unsafe, or phone is locked (these currently PASS but must keep passing after the change).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_whatsapp_driver_verify.py`:
+
+```python
+"""Unit tests for WhatsAppDriver.verify_whatsapp_is_open().
+
+Covers the post-fix behaviour: verifier trusts package + activity + lock-screen
+checks. The legacy resource-ID probe has been removed (issue #27), so verify
+must succeed even when no WhatsApp element IDs are visible.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from whatsapp_chat_autoexport.export.whatsapp_driver import WhatsAppDriver
+
+
+def _make_driver(
+    *,
+    current_package: str = "com.whatsapp",
+    current_activity: str = "com.whatsapp.HomeActivity",
+    is_locked: bool = False,
+    lock_reason: str = "screen on, unlocked",
+) -> WhatsAppDriver:
+    """Build a WhatsAppDriver with its Appium driver and lock check mocked.
+
+    The verifier reads `driver.current_package` and `driver.current_activity`
+    via `safe_driver_call`, and calls `self.check_if_phone_locked()`. Mock
+    those three points and the verifier becomes deterministic.
+    """
+    wd = WhatsAppDriver.__new__(WhatsAppDriver)
+    wd.driver = MagicMock()
+    wd.driver.current_package = current_package
+    wd.driver.current_activity = current_activity
+    wd.logger = MagicMock()
+    wd.safe_driver_call = MagicMock(side_effect=lambda _label, fn, **_kw: fn())
+    wd.check_if_phone_locked = MagicMock(return_value=(is_locked, lock_reason))
+    return wd
+
+
+@pytest.mark.unit
+def test_verify_returns_true_when_package_and_activity_safe():
+    """Material 3 happy path: no legacy IDs visible, package + activity safe."""
+    wd = _make_driver()
+    assert wd.verify_whatsapp_is_open() is True
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_package_not_whatsapp():
+    """Settings or another app foregrounded — must hard-fail."""
+    wd = _make_driver(current_package="com.android.settings")
+    assert wd.verify_whatsapp_is_open() is False
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_activity_unsafe():
+    """Lock screen / system UI / settings activity must hard-fail."""
+    wd = _make_driver(current_activity="com.android.systemui.Keyguard")
+    assert wd.verify_whatsapp_is_open() is False
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_phone_locked():
+    """Final lock check (Check 4) still fires after package + activity pass."""
+    wd = _make_driver(is_locked=True, lock_reason="phone is locked")
+    assert wd.verify_whatsapp_is_open() is False
+```
+
+- [ ] **Step 2: Run tests to verify the happy-path test fails (the bug)**
+
+Run: `poetry run pytest tests/unit/test_whatsapp_driver_verify.py -v`
+
+Expected:
+- `test_verify_returns_true_when_package_and_activity_safe` → **FAIL** (current verifier returns False because Check 3 finds no legacy IDs in the MagicMock).
+- The other three → **PASS** (Checks 1, 2, 4 are unchanged).
+
+This proves the test correctly captures the bug from issue #27.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/test_whatsapp_driver_verify.py
+git commit -m "test: pin verify_whatsapp_is_open() behaviour for Material 3 (#27)
+
+Happy-path test currently fails: verifier rejects Material 3 because
+Check 3 probes legacy resource IDs that no longer exist."
+```
+
+---
+
+## Task 2: Delete Check 3 from `verify_whatsapp_is_open()`
+
+**Files:**
+- Modify: `whatsapp_chat_autoexport/export/whatsapp_driver.py:1272-1329`
+
+- [ ] **Step 1: Delete the Check 3 block**
+
+In `whatsapp_chat_autoexport/export/whatsapp_driver.py`, delete the entire block from line 1272 through 1329 inclusive — that is, from the comment `# Check 3: Verify we can see WhatsApp UI elements` through and including the `return False` and the trailing `self.logger.success("✓ WhatsApp UI elements accessible")` line.
+
+The exact text to remove (verify with `grep -n "Check 3" whatsapp_chat_autoexport/export/whatsapp_driver.py` first to confirm line numbers haven't drifted):
+
+```python
+            # Check 3: Verify we can see WhatsApp UI elements
+            self.logger.info("Checking for WhatsApp UI elements...")
+
+            # Try to find common WhatsApp elements
+            whatsapp_elements_found = False
+
+            # Look for chat list elements
+            try:
+                chat_elements = self.driver.find_elements("id", "com.whatsapp:id/conversations_row_contact_name")
+                if len(chat_elements) > 0:
+                    self.logger.success(f"✓ Found {len(chat_elements)} chat elements")
+                    whatsapp_elements_found = True
+            except Exception as e:
+                self.logger.debug_msg(f"No chat elements found: {e}")
+
+            # Look for toolbar (present on most WhatsApp screens)
+            try:
+                toolbar = self.driver.find_elements("id", "com.whatsapp:id/toolbar")
+                if len(toolbar) > 0:
+                    self.logger.success("✓ Found WhatsApp toolbar")
+                    whatsapp_elements_found = True
+            except Exception as e:
+                self.logger.debug_msg(f"No toolbar found: {e}")
+
+            # Look for action bar (another common element)
+            try:
+                action_bar = self.driver.find_elements("id", "com.whatsapp:id/action_bar")
+                if len(action_bar) > 0:
+                    self.logger.success("✓ Found WhatsApp action bar")
+                    whatsapp_elements_found = True
+            except Exception as e:
+                self.logger.debug_msg(f"No action bar found: {e}")
+
+            # Look for menu button
+            try:
+                menu_button = self.driver.find_elements("id", "com.whatsapp:id/menuitem_search")
+                if len(menu_button) > 0:
+                    self.logger.success("✓ Found WhatsApp menu button")
+                    whatsapp_elements_found = True
+            except Exception as e:
+                self.logger.debug_msg(f"No menu button found: {e}")
+
+            if not whatsapp_elements_found:
+                self.logger.error("=" * 70)
+                self.logger.error("❌ CRITICAL FAILURE: No WhatsApp UI elements found!")
+                self.logger.error("=" * 70)
+                self.logger.error("Package is com.whatsapp but UI is not accessible.")
+                self.logger.error("")
+                self.logger.error("This could mean:")
+                self.logger.error("  - Phone is locked but showing WhatsApp in background")
+                self.logger.error("  - WhatsApp is loading but not ready")
+                self.logger.error("  - Dialog or overlay is blocking WhatsApp UI")
+                self.logger.error("")
+                self.logger.error("⚠️  STOPPING to prevent accidental system UI interaction!")
+                self.logger.error("=" * 70)
+                return False
+
+            self.logger.success("✓ WhatsApp UI elements accessible")
+```
+
+The line immediately before the deletion remains: `self.logger.success(f"✓ Activity confirmed safe: {current_activity}")` (currently line 1270). The line immediately after is the renumbered Check 4 block, beginning `# Check 4: Final lock screen check` (currently line 1331).
+
+After deletion, Check 4's comment stays as-is (`# Check 4: Final lock screen check`) — the gap in numbering is intentional and a useful breadcrumb that this function once had a Check 3.
+
+- [ ] **Step 2: Run the new tests — all four pass**
+
+Run: `poetry run pytest tests/unit/test_whatsapp_driver_verify.py -v`
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Run the full unit + integration suite — no regressions**
+
+Run: `poetry run pytest tests/unit/ tests/integration/ -m "not requires_api and not requires_device and not requires_drive" -q --tb=short`
+
+Expected: all green. If any test fails referencing the deleted block, surface the failure — do not paper over it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add whatsapp_chat_autoexport/export/whatsapp_driver.py
+git commit -m "fix: drop legacy resource-ID probe from verify_whatsapp_is_open (#27)
+
+Check 3 hard-failed on WhatsApp 2.26 Material 3 because the four legacy
+IDs (conversations_row_contact_name, toolbar, action_bar, menuitem_search)
+no longer exist in the redesigned view hierarchy. Checks 1 (package) and
+2 (activity) already prove WhatsApp is foregrounded; Check 4 (lock screen)
+still fires. Verifier shrinks ~57 lines and is now resilient to future
+WhatsApp redesigns that rename view IDs.
+
+Closes the verifier half of #27. Cascade-halt counter follows in the
+next commit so a future verifier regression cannot poison >3 chats."
+```
+
+---
+
+## Task 3: Add cascade-halt test for `ChatExporter`
+
+**Files:**
+- Create: `tests/unit/test_chat_exporter_verify_cascade.py`
+- Reference: `whatsapp_chat_autoexport/export/chat_exporter.py` (the existing `MAX_CONSECUTIVE_RECOVERIES` pattern)
+
+This test pins the new behaviour: if `verify_whatsapp_is_open()` returns False three times in a row, the batch halts with a clear log message and does not attempt the remaining chats.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_chat_exporter_verify_cascade.py`:
+
+```python
+"""Unit tests for ChatExporter's consecutive-verify-failure cascade halt.
+
+Pins the defence-in-depth behaviour added for issue #27: if the verifier
+ever regresses again, the orchestrator halts the batch after 3 consecutive
+verification failures rather than grinding through hundreds of chats.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from whatsapp_chat_autoexport.export.chat_exporter import ChatExporter
+
+
+@pytest.mark.unit
+def test_three_consecutive_verify_failures_halts_batch(tmp_path):
+    """Mock driver where verify always fails; batch must halt at chat 3."""
+    driver = MagicMock()
+    driver.verify_whatsapp_is_open.return_value = False
+    driver.is_session_active.return_value = True
+    driver.reconnect.return_value = False  # any recovery attempt also fails
+
+    logger = MagicMock()
+    logger.debug = False  # match Logger contract used elsewhere
+
+    exporter = ChatExporter(driver, logger)
+
+    chat_names = [f"Chat {i}" for i in range(1, 6)]  # 5 chats
+
+    # Use the legacy `export_chats` path (line 1666 verify call site) — its
+    # cascade-halt logic is structurally simpler to test (no StateManager
+    # setup required). The new-workflow path (`export_chats_with_new_workflow`,
+    # line 501) uses identical counter logic and is exercised in production.
+    results, _timings, _total, _skipped = exporter.export_chats(
+        chat_names=chat_names,
+        include_media=False,
+    )
+
+    # Three verify calls (chats 1, 2, 3) — then the limit fires and the loop
+    # breaks before chat 4's verify call.
+    assert driver.verify_whatsapp_is_open.call_count == ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES, (
+        f"Expected exactly {ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES} verify "
+        f"calls before halt, got {driver.verify_whatsapp_is_open.call_count}"
+    )
+
+    # Chats 4 and 5 must not appear in results — the batch halted before them.
+    assert "Chat 4" not in results
+    assert "Chat 5" not in results
+
+    # Chats 1–3 are recorded as failed.
+    for n in (1, 2, 3):
+        assert results.get(f"Chat {n}") is False, f"Chat {n} should be recorded as failed"
+
+    # The halt message reaches the logger.
+    halt_messages = [
+        call for call in logger.error.call_args_list
+        if "consecutive WhatsApp verification failures" in str(call)
+    ]
+    assert halt_messages, "Expected a 'consecutive verify failures' halt log message"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `poetry run pytest tests/unit/test_chat_exporter_verify_cascade.py -v`
+
+Expected: **FAIL** — `MAX_CONSECUTIVE_VERIFY_FAILURES` does not exist on `ChatExporter`. Likely an `AttributeError`.
+
+This proves the test is exercising the not-yet-implemented behaviour.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/unit/test_chat_exporter_verify_cascade.py
+git commit -m "test: pin cascade-halt at 3 consecutive verify failures (#27)
+
+Defence-in-depth so a future verifier regression cannot poison more
+than 3 chats. Test fails until MAX_CONSECUTIVE_VERIFY_FAILURES and the
+counter are wired in chat_exporter.py."
+```
+
+---
+
+## Task 4: Implement cascade-halt in `ChatExporter`
+
+**Files:**
+- Modify: `whatsapp_chat_autoexport/export/chat_exporter.py` — five edit sites
+
+Make all five edits in this single task (one task per file is the right granularity here — they're a coherent set), then run the suite.
+
+- [ ] **Step 1: Add the class constant alongside `MAX_CONSECUTIVE_RECOVERIES`**
+
+In `chat_exporter.py`, find the existing constant at line 145:
+
+```python
+    # Max consecutive recovery attempts before aborting the batch.
+    # 1 = transient, 2 = unlucky, 3 = systemic issue (phone overheating, OOM, etc.)
+    MAX_CONSECUTIVE_RECOVERIES = 3
+```
+
+Replace it with:
+
+```python
+    # Max consecutive recovery attempts before aborting the batch.
+    # 1 = transient, 2 = unlucky, 3 = systemic issue (phone overheating, OOM, etc.)
+    MAX_CONSECUTIVE_RECOVERIES = 3
+
+    # Max consecutive verify_whatsapp_is_open() failures before aborting the batch.
+    # Defence-in-depth (issue #27): a regressed verifier cannot poison more than
+    # this many chats. Counter is independent of MAX_CONSECUTIVE_RECOVERIES.
+    MAX_CONSECUTIVE_VERIFY_FAILURES = 3
+```
+
+- [ ] **Step 2: Add the instance counter alongside `_consecutive_recovery_count`**
+
+Find lines 160-161:
+
+```python
+        # Session recovery tracking
+        self._consecutive_recovery_count: int = 0
+```
+
+Replace with:
+
+```python
+        # Session recovery tracking
+        self._consecutive_recovery_count: int = 0
+        # Verify-failure cascade tracking (issue #27)
+        self._consecutive_verify_failure_count: int = 0
+```
+
+- [ ] **Step 3: Add the helper next to `_check_consecutive_recovery_limit`**
+
+Find the existing helper at line 217-230:
+
+```python
+    def _check_consecutive_recovery_limit(self) -> bool:
+        """Check if the consecutive recovery limit has been reached.
+
+        Returns:
+            True if the limit has been reached (batch should stop), False otherwise.
+        """
+        if self._consecutive_recovery_count >= self.MAX_CONSECUTIVE_RECOVERIES:
+            self.logger.error(
+                f"Stopping batch: {self._consecutive_recovery_count} consecutive session recoveries "
+                f"reached the limit of {self.MAX_CONSECUTIVE_RECOVERIES}. "
+                f"This suggests a systemic issue (phone overheating, memory exhaustion, etc.)"
+            )
+            return True
+        return False
+```
+
+Add immediately after it:
+
+```python
+    def _check_consecutive_verify_failure_limit(self) -> bool:
+        """Check if the consecutive verify-failure limit has been reached.
+
+        Returns:
+            True if the limit has been reached (batch should stop), False otherwise.
+        """
+        if self._consecutive_verify_failure_count >= self.MAX_CONSECUTIVE_VERIFY_FAILURES:
+            self.logger.error(
+                f"Stopping batch: {self._consecutive_verify_failure_count} consecutive WhatsApp "
+                f"verification failures reached the limit of {self.MAX_CONSECUTIVE_VERIFY_FAILURES}. "
+                "The verifier may be regressed; investigate before re-running."
+            )
+            return True
+        return False
+```
+
+- [ ] **Step 4: Wire counter increment + check at the two batch verify call sites**
+
+There are two batch methods that call `verify_whatsapp_is_open()`:
+- `export_chats_with_new_workflow()` — verify at **line 501**, the active TUI path. Uses `state_manager.fail_chat()`.
+- `export_chats()` — verify at **line 1666**, the legacy path. Uses `chat_timings` instead of state_manager.
+
+Both need the cascade-halt; their wiring differs slightly because their failure-recording machinery differs.
+
+**Site A — line 501 in `export_chats_with_new_workflow`:**
+
+Find (currently lines 499-509):
+
+```python
+            # CRITICAL: Verify WhatsApp is still accessible before each export.
+            # If verification fails, attempt session recovery before aborting.
+            if not self.driver.verify_whatsapp_is_open():
+                state_manager = self._get_state_manager()
+                if self._check_consecutive_recovery_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    if state_manager.has_session:
+                        state_manager.fail_chat(chat_name, "Consecutive recovery limit reached")
+                    break
+                if self._attempt_session_recovery("Pre-export verification failed"):
+```
+
+Replace with:
+
+```python
+            # CRITICAL: Verify WhatsApp is still accessible before each export.
+            # If verification fails, attempt session recovery before aborting.
+            if not self.driver.verify_whatsapp_is_open():
+                self._consecutive_verify_failure_count += 1
+                state_manager = self._get_state_manager()
+                if self._check_consecutive_verify_failure_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    if state_manager.has_session:
+                        state_manager.fail_chat(chat_name, "Consecutive verify-failure limit reached")
+                    break
+                if self._check_consecutive_recovery_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    if state_manager.has_session:
+                        state_manager.fail_chat(chat_name, "Consecutive recovery limit reached")
+                    break
+                if self._attempt_session_recovery("Pre-export verification failed"):
+```
+
+The verify-failure check is checked **before** the recovery-limit check because verify-failures halt the batch *without* attempting recovery (recovery itself re-invokes the verifier — exactly the cascade we're guarding against).
+
+**Site B — line 1666 in `export_chats` (legacy path):**
+
+Find (currently lines 1664-1672):
+
+```python
+            # CRITICAL: Verify WhatsApp is still accessible before each export.
+            # If verification fails, attempt session recovery before aborting.
+            if not self.driver.verify_whatsapp_is_open():
+                if self._check_consecutive_recovery_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    ct.status = ChatStatus.FAILED
+                    self.chat_timings.append(ct)
+                    break
+                if self._attempt_session_recovery("Pre-export verification failed"):
+```
+
+Replace with:
+
+```python
+            # CRITICAL: Verify WhatsApp is still accessible before each export.
+            # If verification fails, attempt session recovery before aborting.
+            if not self.driver.verify_whatsapp_is_open():
+                self._consecutive_verify_failure_count += 1
+                if self._check_consecutive_verify_failure_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    ct.status = ChatStatus.FAILED
+                    self.chat_timings.append(ct)
+                    break
+                if self._check_consecutive_recovery_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    ct.status = ChatStatus.FAILED
+                    self.chat_timings.append(ct)
+                    break
+                if self._attempt_session_recovery("Pre-export verification failed"):
+```
+
+Note `ct` (`ChatTiming`) and `ChatStatus.FAILED` are already in scope at this point in `export_chats` — see lines 1662, 1670 for the existing pattern.
+
+- [ ] **Step 5: Wire counter reset at the four reset sites**
+
+**Reset Sites — start-of-batch (lines 484, 1645):**
+
+Find each `self._consecutive_recovery_count = 0` at the top of the batch loops and add a sibling line:
+
+Before:
+```python
+        self._consecutive_recovery_count = 0
+```
+
+After:
+```python
+        self._consecutive_recovery_count = 0
+        self._consecutive_verify_failure_count = 0
+```
+
+**Reset Sites — after a fully successful export (lines 580, 1775):**
+
+Find each:
+```python
+                else:
+                    # A fully successful export resets the consecutive counter
+                    self._consecutive_recovery_count = 0
+```
+
+Replace with:
+```python
+                else:
+                    # A fully successful export resets the consecutive counters
+                    self._consecutive_recovery_count = 0
+                    self._consecutive_verify_failure_count = 0
+```
+
+If line numbers have drifted, locate by `grep -n "consecutive counter" whatsapp_chat_autoexport/export/chat_exporter.py`.
+
+- [ ] **Step 6: Run the cascade test — passes**
+
+Run: `poetry run pytest tests/unit/test_chat_exporter_verify_cascade.py -v`
+
+Expected: 1 passed.
+
+- [ ] **Step 7: Run the full suite — no regressions**
+
+Run: `poetry run pytest tests/unit/ tests/integration/ -m "not requires_api and not requires_device and not requires_drive" -q --tb=short`
+
+Expected: all green. Pay special attention to:
+- `tests/unit/test_export_recovery.py` — exercises the existing recovery counter; new counter must not interfere.
+- `tests/unit/test_export_pane.py` — uses the per-chat verify path; behaviour unchanged from its perspective.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add whatsapp_chat_autoexport/export/chat_exporter.py
+git commit -m "feat: halt batch after 3 consecutive verify failures (#27)
+
+Adds MAX_CONSECUTIVE_VERIFY_FAILURES=3 and
+_consecutive_verify_failure_count alongside the existing recovery
+counter. Wired into both batch verify call sites; reset at start of
+batch and after each successful export.
+
+Defence-in-depth: if verify_whatsapp_is_open() ever regresses again,
+the batch halts at chat 3, not chat 874. Independent of the recovery
+counter — verify-failures halt before recovery is attempted because
+recovery itself re-invokes the verifier.
+
+Closes #27."
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none — this task is just running the local pre-flight gates.
+
+- [ ] **Step 1: Run the project's `unit-tests` recipe explicitly**
+
+Run: `poetry run pytest tests/unit/ tests/integration/ -m "not requires_api and not requires_device and not requires_drive" -q --tb=short`
+
+Expected: all green.
+
+- [ ] **Step 2: Run the project's `help-flag` recipe**
+
+Run: `poetry run whatsapp --help`
+
+Expected: exit 0; output contains `--headless`. (`.claude/testing.md` recipe.)
+
+- [ ] **Step 3: Confirm the verifier really lost Check 3**
+
+Run: `grep -n "Check 3\|conversations_row_contact_name\|menuitem_search" whatsapp_chat_autoexport/export/whatsapp_driver.py`
+
+Expected: no matches in `verify_whatsapp_is_open()` (other matches elsewhere in the file are fine — those are unrelated selectors).
+
+- [ ] **Step 4: Confirm the cascade counter exists**
+
+Run: `grep -n "MAX_CONSECUTIVE_VERIFY_FAILURES\|_consecutive_verify_failure_count" whatsapp_chat_autoexport/export/chat_exporter.py`
+
+Expected: at least 7 matches — class constant (1), instance counter init (1), helper definition (3 lines reference it), increment sites (2), reset sites (4). Roughly 11+ lines total.
+
+- [ ] **Step 5: No-op**
+
+If all four steps above passed, the implementation is done. Hand back to `aj-flow flow` Step 9 (Verify) and Step 10 (Self-review).
+
+---
+
+## Self-Review Checklist (run before handing off)
+
+- [x] **Spec coverage:** Each goal in the spec maps to a task — Goal 1 (verifier passes on Material 3) → Task 1 + 2; Goal 2 (still rejects bad states) → Task 1's three negative tests; Goal 3 (cascade halt at N=3) → Task 3 + 4. Acceptance criteria covered by Task 5.
+- [x] **No placeholders:** Every step has the actual code or the actual command. Line numbers caveated with `grep` confirmations in case of drift.
+- [x] **Type / name consistency:** `MAX_CONSECUTIVE_VERIFY_FAILURES` and `_consecutive_verify_failure_count` used identically across spec, plan, tests, and prod code. Helper name `_check_consecutive_verify_failure_limit` mirrors existing `_check_consecutive_recovery_limit`.
+- [x] **Existing-code respect:** Mirrors the existing `MAX_CONSECUTIVE_RECOVERIES` pattern exactly — same structure, same naming, same reset points. Reviewer can reason by analogy.

--- a/docs/superpowers/specs/2026-04-30-relax-verify-whatsapp-is-open-design.md
+++ b/docs/superpowers/specs/2026-04-30-relax-verify-whatsapp-is-open-design.md
@@ -1,0 +1,138 @@
+# Spec — Relax `verify_whatsapp_is_open()` for WhatsApp 2.26 Material 3
+
+- **Issue:** [#27](https://github.com/ajanderson1/whatsapp_chat_autoexport/issues/27) — `fix: relax verify_whatsapp_is_open for WhatsApp 2.26 Material 3 redesign`
+- **Status:** Approved (guided brainstorm, 2026-04-30)
+- **Date:** 2026-04-30
+- **Author:** AJ Anderson via aj-flow
+
+## Problem
+
+`verify_whatsapp_is_open()` in `whatsapp_chat_autoexport/export/whatsapp_driver.py:1211-1349` returns `False` on WhatsApp 2.26.15.76 (Material 3 redesign) because Check 3 (lines 1272-1329) probes four hardcoded legacy resource IDs that no longer exist in the redesigned view hierarchy:
+
+- `com.whatsapp:id/conversations_row_contact_name`
+- `com.whatsapp:id/toolbar`
+- `com.whatsapp:id/action_bar`
+- `com.whatsapp:id/menuitem_search`
+
+When all four come back empty, Check 3 hard-fails — even though Check 1 (current package == `com.whatsapp`) and Check 2 (current activity not in unsafe list) have already proven WhatsApp is foregrounded and safe.
+
+**Real-world impact:** an autonomous full-export run against 874 chats aborted after 1 successful chat (transient cached fragment matched a legacy ID once). Every subsequent chat hit `WhatsApp verification failed`, and `_attempt_session_recovery()` re-invoked the same broken verifier on every retry, poisoning the entire batch.
+
+Full diagnosis: `docs/solutions/integration-issues/whatsapp-material3-resource-id-allowlist-2026-04-30.md`.
+
+## Goals
+
+1. `verify_whatsapp_is_open()` returns `True` on WhatsApp 2.26.15.76 (Material 3) when WhatsApp is foregrounded and unlocked.
+2. `verify_whatsapp_is_open()` continues to return `False` when the wrong package is foreground or the activity is unsafe (lock screen, system UI, settings).
+3. A future verifier regression cannot poison more than 3 chats in a batch run before the orchestrator halts.
+
+## Non-goals
+
+- Updating `create_default_selectors()` in `config/selectors.py` for `export_chat_option`, `chat_list_item`, `toolbar`, or `menu_button`. Those need real Appium Inspector dumps against 2.26.x to confirm new IDs and belong in a follow-up issue with device-verification artifacts.
+- Adding versioned per-build YAML selectors under `config/selectors/whatsapp_2.26.yaml`. YAGNI for one build; revisit when a second build forces selector divergence.
+- Selector-drift CI smoke tests, monthly release-monitoring agents, or the broader Prevention list from the diagnosis doc.
+- Changes to `export_pane.py:563` — that call site is per-chat in the TUI and does not own a batch loop. Verifier-relaxation alone fixes the cascade there.
+- Changes to legacy code paths (`legacy/cli/commands/export.py`, `legacy/textual_screens/export_screen.py`, `whatsapp_export.py`).
+
+## Design
+
+### Change 1 — Delete Check 3 from `verify_whatsapp_is_open()`
+
+**File:** `whatsapp_chat_autoexport/export/whatsapp_driver.py`
+**Lines affected:** 1272-1329 (Check 3 block) — deleted in full.
+
+Checks 1 and 2 already prove WhatsApp is foregrounded:
+
+- **Check 1** (lines 1225-1250): asserts `current_package == "com.whatsapp"`, hard-fails otherwise.
+- **Check 2** (lines 1252-1270): asserts current activity is not in `["Keyguard", "LockScreen", "lockscreen", "StatusBar", "systemui", "Settings"]`, hard-fails otherwise.
+
+Check 3 was belt-and-braces — meant as a sanity probe that WhatsApp UI was actually rendered. The implementation conflated "no legacy IDs visible" with "WhatsApp is not foregrounded," a category error that turned the safety net into a guillotine.
+
+**Check 4** (lines 1331-1343, the final lock-screen check) is retained — it adds a real signal not covered by Checks 1 and 2 (the screen could be on but locked while WhatsApp is technically the foreground app).
+
+The function shrinks from 139 lines to ~80 lines. The `try/except` at the outer level (lines 1224 and 1351-1359) is preserved — any exception during package/activity probes still hard-fails, which is correct.
+
+### Change 2 — Cascade-halt counter in `ChatExporter`
+
+**File:** `whatsapp_chat_autoexport/export/chat_exporter.py`
+
+Add alongside the existing `_consecutive_recovery_count`:
+
+```python
+class ChatExporter:
+    MAX_CONSECUTIVE_RECOVERIES = 3          # existing, line 145
+    MAX_CONSECUTIVE_VERIFY_FAILURES = 3     # NEW
+
+    def __init__(self, ...):
+        ...
+        self._consecutive_recovery_count: int = 0          # existing
+        self._consecutive_verify_failure_count: int = 0    # NEW
+```
+
+Add a small helper:
+
+```python
+def _check_consecutive_verify_failure_limit(self) -> bool:
+    """Return True if N consecutive verify failures have aborted the batch."""
+    if self._consecutive_verify_failure_count >= self.MAX_CONSECUTIVE_VERIFY_FAILURES:
+        self.logger.error(
+            f"Stopping batch: {self._consecutive_verify_failure_count} consecutive "
+            f"WhatsApp verification failures reached the limit of "
+            f"{self.MAX_CONSECUTIVE_VERIFY_FAILURES}. The verifier may be regressed; "
+            "investigate before re-running."
+        )
+        return True
+    return False
+```
+
+Wire it into the two batch-loop verify call sites:
+
+- **Line 501** (`export_chats_to_google_drive`): on `verify_whatsapp_is_open() == False`, increment the counter; if `_check_consecutive_verify_failure_limit()` returns True, break the loop with a `state_manager.fail_chat()` reason of `"Consecutive verify-failure limit reached"`.
+- **Line 1666** (`export_chats_to_google_drive_with_session_recovery`, the resumable variant): same wiring.
+
+Reset to 0 in the same places `_consecutive_recovery_count` is reset:
+
+- Line 484 / 1645 (start of batch).
+- Line 580 / 1775 (after a fully successful export).
+
+The existing recovery flow is preserved unchanged. The new counter is a separate failure mode and stops the batch *before* recovery is attempted (since recovery itself re-invokes the verifier — exactly the cascade we're guarding against).
+
+### Change 3 — Tests
+
+**File:** `tests/unit/test_whatsapp_driver_verify.py` (new) — covers the verifier:
+
+1. `test_verify_returns_true_when_package_and_activity_safe` — mock driver: package `com.whatsapp`, activity `com.whatsapp.HomeActivity`, lock check returns unlocked. Assert `True`. (Pins post-fix happy path; would fail under current code on Material 3.)
+2. `test_verify_returns_false_when_package_not_whatsapp` — mock driver: package `com.android.settings`. Assert `False`. (Pins Check 1.)
+3. `test_verify_returns_false_when_activity_unsafe` — mock driver: package `com.whatsapp`, activity `com.android.systemui.Keyguard`. Assert `False`. (Pins Check 2.)
+4. `test_verify_returns_false_when_phone_locked` — mock driver: package + activity safe, but `check_if_phone_locked()` returns True. Assert `False`. (Pins Check 4.)
+
+**File:** `tests/unit/test_chat_exporter_verify_cascade.py` (new) — covers the cascade-halt:
+
+5. `test_three_consecutive_verify_failures_halts_batch` — mock driver where `verify_whatsapp_is_open()` always returns False. Submit a batch of 5 chats. Assert the loop breaks at chat 3, the remaining chats are not attempted, and the batch logs the consecutive-verify-failure stop message.
+
+All five tests are pure unit tests with no Appium dependency, no `requires_device` marker, runnable in CI.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Removing Check 3 lets a non-WhatsApp screen slip through if Checks 1+2 are wrong | Low | Checks 1 and 2 read directly from Appium's session — there is no realistic path where they report `com.whatsapp` + safe activity but the foreground is something else. The original belt-and-braces was a category error, not a real second signal. |
+| `MAX_CONSECUTIVE_VERIFY_FAILURES = 3` is too aggressive on a flaky network | Low | The verifier never hits the network — only `current_package`, `current_activity`, and a lock probe. Three consecutive failures of those is a real broken state, not flakiness. |
+| Cascade-halt collides with `_attempt_session_recovery`'s own retry budget | Low | The two counters are independent: verify-failures halt *before* recovery is attempted; recovery-count halts after recovery has been attempted. Both can fire within the same run; either firing halts the batch. |
+| Other call sites (`export_pane.py:563`, `interactive.py:138`, etc.) still rely on the verifier and won't get the cascade guard | Accepted | The bug they hit is fixed by Change 1 alone. Each non-batch caller fails fast on a single `False`, which is the correct behaviour outside a batch loop. |
+
+## Acceptance criteria
+
+- All four verifier unit tests in `test_whatsapp_driver_verify.py` pass.
+- The cascade unit test in `test_chat_exporter_verify_cascade.py` passes.
+- Existing `pytest tests/unit/ tests/integration/ -m "not requires_api and not requires_device and not requires_drive"` suite passes (no regressions).
+- `poetry run whatsapp --help` exit 0, output contains `--headless` (per `.claude/testing.md`'s `help-flag` recipe).
+- `verify_whatsapp_is_open()` no longer references the four legacy resource IDs.
+- `ChatExporter` has `MAX_CONSECUTIVE_VERIFY_FAILURES` class constant and `_consecutive_verify_failure_count` instance counter.
+- Issue #27 referenced in the PR body via `Closes #27`.
+
+## Related
+
+- `docs/solutions/integration-issues/whatsapp-material3-resource-id-allowlist-2026-04-30.md` — full diagnosis including Open Questions; this spec resolves all six.
+- `docs/failure-reports/2026-04-16-full-run-pause.md` — separate verifier failure (focus-return race); not addressed here, but the simplified verifier reduces surface area.
+- `docs/plans/2026-04-17-001-fix-full-run-failures-plan.md` — active plan; cross-reference both ways but land standalone.

--- a/tests/unit/test_chat_exporter_verify_cascade.py
+++ b/tests/unit/test_chat_exporter_verify_cascade.py
@@ -1,0 +1,59 @@
+"""Unit tests for ChatExporter's consecutive-verify-failure cascade halt.
+
+Pins the defence-in-depth behaviour added for issue #27: if the verifier
+ever regresses again, the orchestrator halts the batch after 3 consecutive
+verification failures rather than grinding through hundreds of chats.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from whatsapp_chat_autoexport.export.chat_exporter import ChatExporter
+
+
+@pytest.mark.unit
+def test_three_consecutive_verify_failures_halts_batch(tmp_path):
+    """Mock driver where verify always fails; batch must halt at chat 3."""
+    driver = MagicMock()
+    driver.verify_whatsapp_is_open.return_value = False
+    driver.is_session_active.return_value = True
+    driver.reconnect.return_value = False  # any recovery attempt also fails
+
+    logger = MagicMock()
+    logger.debug = False  # match Logger contract used elsewhere
+
+    exporter = ChatExporter(driver, logger)
+
+    chat_names = [f"Chat {i}" for i in range(1, 6)]  # 5 chats
+
+    # Use the legacy `export_chats` path (line 1666 verify call site) — its
+    # cascade-halt logic is structurally simpler to test (no StateManager
+    # setup required). The new-workflow path (`export_chats_with_new_workflow`,
+    # line 501) uses identical counter logic and is exercised in production.
+    results, _timings, _total, _skipped = exporter.export_chats(
+        chat_names=chat_names,
+        include_media=False,
+    )
+
+    # Three verify calls (chats 1, 2, 3) — then the limit fires and the loop
+    # breaks before chat 4's verify call.
+    assert driver.verify_whatsapp_is_open.call_count == ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES, (
+        f"Expected exactly {ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES} verify "
+        f"calls before halt, got {driver.verify_whatsapp_is_open.call_count}"
+    )
+
+    # Chats 4 and 5 must not appear in results — the batch halted before them.
+    assert "Chat 4" not in results
+    assert "Chat 5" not in results
+
+    # Chats 1-3 are recorded as failed.
+    for n in (1, 2, 3):
+        assert results.get(f"Chat {n}") is False, f"Chat {n} should be recorded as failed"
+
+    # The halt message reaches the logger.
+    halt_messages = [
+        call for call in logger.error.call_args_list
+        if "consecutive WhatsApp verification failures" in str(call)
+    ]
+    assert halt_messages, "Expected a 'consecutive verify failures' halt log message"

--- a/tests/unit/test_export_recovery.py
+++ b/tests/unit/test_export_recovery.py
@@ -178,18 +178,29 @@ class TestExportChatsRecovery:
         assert results["Chat A"] is False
         assert results["Chat B"] is True
 
-    def test_pre_verify_fails_recovery_fails_breaks(self, exporter, mock_driver):
-        """When verify fails and recovery also fails, batch stops."""
-        mock_driver.verify_whatsapp_is_open.side_effect = [False, False]
+    def test_pre_verify_fails_recovery_fails_continues_until_cascade_limit(self, exporter, mock_driver):
+        """When verify fails and recovery also fails, batch continues until the
+        cascade limit (#27): each chat is recorded as failed and the loop moves
+        on; the verify-failure cascade counter halts the batch after
+        MAX_CONSECUTIVE_VERIFY_FAILURES consecutive failures.
+        """
+        mock_driver.verify_whatsapp_is_open.return_value = False
         mock_driver.reconnect.return_value = False
 
+        # Provide enough chats to exceed the cascade limit
+        chat_names = [f"Chat {n}" for n in range(1, 6)]
+
         results, timings, total_time, skipped = exporter.export_chats(
-            ["Chat A", "Chat B", "Chat C"], include_media=True
+            chat_names, include_media=True
         )
 
-        # Only Chat A should be in results (batch broke)
-        assert results["Chat A"] is False
-        assert "Chat B" not in results
+        # The cascade limit halts after MAX_CONSECUTIVE_VERIFY_FAILURES chats.
+        from whatsapp_chat_autoexport.export.chat_exporter import ChatExporter
+        for n in range(1, ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES + 1):
+            assert results.get(f"Chat {n}") is False
+        # Chats beyond the cascade limit must not be processed.
+        for n in range(ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES + 1, 6):
+            assert f"Chat {n}" not in results
 
     def test_session_error_exception_recovery_succeeds(self, exporter, mock_driver):
         """Session error in exception handler triggers recovery and continues."""
@@ -311,18 +322,26 @@ class TestExportChatsNewWorkflowRecovery:
         assert results["Chat A"] is False
         assert results["Chat B"] is True
 
-    def test_pre_verify_fails_recovery_fails_breaks(self, exporter, mock_driver):
-        """When verify fails and recovery fails, batch stops with state manager update."""
-        mock_driver.verify_whatsapp_is_open.side_effect = [False, False]
+    def test_pre_verify_fails_recovery_fails_continues_until_cascade_limit(self, exporter, mock_driver):
+        """When verify fails and recovery fails, batch continues until the
+        cascade limit (#27); state manager is notified for each failed chat
+        and the loop halts at MAX_CONSECUTIVE_VERIFY_FAILURES.
+        """
+        mock_driver.verify_whatsapp_is_open.return_value = False
         mock_driver.reconnect.return_value = False
 
+        chat_names = [f"Chat {n}" for n in range(1, 6)]
+
         results, timings, total_time, skipped = exporter.export_chats_with_new_workflow(
-            ["Chat A", "Chat B"], include_media=True
+            chat_names, include_media=True
         )
 
-        assert results["Chat A"] is False
-        assert "Chat B" not in results
-        # State manager should have been notified
+        from whatsapp_chat_autoexport.export.chat_exporter import ChatExporter
+        for n in range(1, ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES + 1):
+            assert results.get(f"Chat {n}") is False
+        for n in range(ChatExporter.MAX_CONSECUTIVE_VERIFY_FAILURES + 1, 6):
+            assert f"Chat {n}" not in results
+        # State manager should have been notified for each failed chat.
         exporter._state_manager.fail_chat.assert_called()
 
     def test_session_error_exception_with_state_manager(self, exporter, mock_driver):

--- a/tests/unit/test_whatsapp_driver_verify.py
+++ b/tests/unit/test_whatsapp_driver_verify.py
@@ -1,0 +1,63 @@
+"""Unit tests for WhatsAppDriver.verify_whatsapp_is_open().
+
+Covers the post-fix behaviour: verifier trusts package + activity + lock-screen
+checks. The legacy resource-ID probe has been removed (issue #27), so verify
+must succeed even when no WhatsApp element IDs are visible.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from whatsapp_chat_autoexport.export.whatsapp_driver import WhatsAppDriver
+
+
+def _make_driver(
+    *,
+    current_package: str = "com.whatsapp",
+    current_activity: str = "com.whatsapp.HomeActivity",
+    is_locked: bool = False,
+    lock_reason: str = "screen on, unlocked",
+) -> WhatsAppDriver:
+    """Build a WhatsAppDriver with its Appium driver and lock check mocked.
+
+    The verifier reads `driver.current_package` and `driver.current_activity`
+    via `safe_driver_call`, and calls `self.check_if_phone_locked()`. Mock
+    those three points and the verifier becomes deterministic.
+    """
+    wd = WhatsAppDriver.__new__(WhatsAppDriver)
+    wd.driver = MagicMock()
+    wd.driver.current_package = current_package
+    wd.driver.current_activity = current_activity
+    wd.logger = MagicMock()
+    wd.safe_driver_call = MagicMock(side_effect=lambda _label, fn, **_kw: fn())
+    wd.check_if_phone_locked = MagicMock(return_value=(is_locked, lock_reason))
+    return wd
+
+
+@pytest.mark.unit
+def test_verify_returns_true_when_package_and_activity_safe():
+    """Material 3 happy path: no legacy IDs visible, package + activity safe."""
+    wd = _make_driver()
+    assert wd.verify_whatsapp_is_open() is True
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_package_not_whatsapp():
+    """Settings or another app foregrounded — must hard-fail."""
+    wd = _make_driver(current_package="com.android.settings")
+    assert wd.verify_whatsapp_is_open() is False
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_activity_unsafe():
+    """Lock screen / system UI / settings activity must hard-fail."""
+    wd = _make_driver(current_activity="com.android.systemui.Keyguard")
+    assert wd.verify_whatsapp_is_open() is False
+
+
+@pytest.mark.unit
+def test_verify_returns_false_when_phone_locked():
+    """Final lock check (Check 4) still fires after package + activity pass."""
+    wd = _make_driver(is_locked=True, lock_reason="phone is locked")
+    assert wd.verify_whatsapp_is_open() is False

--- a/whatsapp_chat_autoexport/export/chat_exporter.py
+++ b/whatsapp_chat_autoexport/export/chat_exporter.py
@@ -144,6 +144,11 @@ class ChatExporter:
     # 1 = transient, 2 = unlucky, 3 = systemic issue (phone overheating, OOM, etc.)
     MAX_CONSECUTIVE_RECOVERIES = 3
 
+    # Max consecutive verify_whatsapp_is_open() failures before aborting the batch.
+    # Defence-in-depth (issue #27): a regressed verifier cannot poison more than
+    # this many chats. Counter is independent of MAX_CONSECUTIVE_RECOVERIES.
+    MAX_CONSECUTIVE_VERIFY_FAILURES = 3
+
     def __init__(self, driver: WhatsAppDriver, logger: Logger, pipeline: Optional['WhatsAppPipeline'] = None):
         self.driver = driver
         self.logger = logger
@@ -159,6 +164,9 @@ class ChatExporter:
 
         # Session recovery tracking
         self._consecutive_recovery_count: int = 0
+
+        # Verify-failure cascade tracking (issue #27)
+        self._consecutive_verify_failure_count: int = 0
 
         # Per-chat structured timing (populated by export_chats)
         self.chat_timings: List[ChatTiming] = []
@@ -225,6 +233,21 @@ class ChatExporter:
                 f"Stopping batch: {self._consecutive_recovery_count} consecutive session recoveries "
                 f"reached the limit of {self.MAX_CONSECUTIVE_RECOVERIES}. "
                 f"This suggests a systemic issue (phone overheating, memory exhaustion, etc.)"
+            )
+            return True
+        return False
+
+    def _check_consecutive_verify_failure_limit(self) -> bool:
+        """Check if the consecutive verify-failure limit has been reached.
+
+        Returns:
+            True if the limit has been reached (batch should stop), False otherwise.
+        """
+        if self._consecutive_verify_failure_count >= self.MAX_CONSECUTIVE_VERIFY_FAILURES:
+            self.logger.error(
+                f"Stopping batch: {self._consecutive_verify_failure_count} consecutive WhatsApp "
+                f"verification failures reached the limit of {self.MAX_CONSECUTIVE_VERIFY_FAILURES}. "
+                "The verifier may be regressed; investigate before re-running."
             )
             return True
         return False
@@ -482,6 +505,7 @@ class ChatExporter:
 
         # Reset consecutive recovery counter at the start of each batch
         self._consecutive_recovery_count = 0
+        self._consecutive_verify_failure_count = 0
 
         for i, chat_name in enumerate(chat_names, 1):
             self.logger.info(f"\nProcessing chat {i}/{total}: '{chat_name}'")
@@ -499,7 +523,14 @@ class ChatExporter:
             # CRITICAL: Verify WhatsApp is still accessible before each export.
             # If verification fails, attempt session recovery before aborting.
             if not self.driver.verify_whatsapp_is_open():
+                self._consecutive_verify_failure_count += 1
                 state_manager = self._get_state_manager()
+                if self._check_consecutive_verify_failure_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    if state_manager.has_session:
+                        state_manager.fail_chat(chat_name, "Consecutive verify-failure limit reached")
+                    break
                 if self._check_consecutive_recovery_limit():
                     results[chat_name] = False
                     timings[chat_name] = 0
@@ -514,12 +545,21 @@ class ChatExporter:
                         state_manager.fail_chat(chat_name, "Session recovered - skipping to next chat")
                     continue
                 else:
-                    self.logger.error(f"WhatsApp is not accessible - cannot export '{chat_name}'. Stopping batch.")
+                    # Recovery failed — record failure and continue. The
+                    # verify-failure cascade counter (above) is the dominant
+                    # halt mechanism; if the verifier is regressed, recovery
+                    # will keep failing too, but the counter still ticks each
+                    # iteration and halts the batch at MAX_CONSECUTIVE_VERIFY_FAILURES.
+                    self.logger.warning(
+                        f"Pre-export verification failed for '{chat_name}' "
+                        f"and session recovery did not succeed "
+                        f"(consecutive verify failures: {self._consecutive_verify_failure_count})"
+                    )
                     results[chat_name] = False
                     timings[chat_name] = 0
                     if state_manager.has_session:
                         state_manager.fail_chat(chat_name, "WhatsApp became inaccessible")
-                    break
+                    continue
 
             chat_start_time = time.time()
 
@@ -576,8 +616,9 @@ class ChatExporter:
                         self.logger.error("Failed to recover session after export - stopping batch")
                         break
                 else:
-                    # A fully successful export resets the consecutive counter
+                    # A fully successful export resets the consecutive counters
                     self._consecutive_recovery_count = 0
+                    self._consecutive_verify_failure_count = 0
 
             except Exception as e:
                 error_msg = str(e)
@@ -1643,6 +1684,7 @@ class ChatExporter:
 
         # Reset consecutive recovery counter at the start of each batch
         self._consecutive_recovery_count = 0
+        self._consecutive_verify_failure_count = 0
 
         # Set up parallel pipeline if pipeline is configured
         parallel: Optional[ParallelPipeline] = None
@@ -1664,6 +1706,13 @@ class ChatExporter:
             # CRITICAL: Verify WhatsApp is still accessible before each export.
             # If verification fails, attempt session recovery before aborting.
             if not self.driver.verify_whatsapp_is_open():
+                self._consecutive_verify_failure_count += 1
+                if self._check_consecutive_verify_failure_limit():
+                    results[chat_name] = False
+                    timings[chat_name] = 0
+                    ct.status = ChatStatus.FAILED
+                    self.chat_timings.append(ct)
+                    break
                 if self._check_consecutive_recovery_limit():
                     results[chat_name] = False
                     timings[chat_name] = 0
@@ -1678,12 +1727,21 @@ class ChatExporter:
                     self.chat_timings.append(ct)
                     continue
                 else:
-                    self.logger.error(f"WhatsApp is not accessible - cannot export '{chat_name}'. Stopping batch.")
+                    # Recovery failed — record failure and continue. The
+                    # verify-failure cascade counter (above) is the dominant
+                    # halt mechanism; if the verifier is regressed, recovery
+                    # will keep failing too, but the counter still ticks each
+                    # iteration and halts the batch at MAX_CONSECUTIVE_VERIFY_FAILURES.
+                    self.logger.warning(
+                        f"Pre-export verification failed for '{chat_name}' "
+                        f"and session recovery did not succeed "
+                        f"(consecutive verify failures: {self._consecutive_verify_failure_count})"
+                    )
                     results[chat_name] = False
                     timings[chat_name] = 0
                     ct.status = ChatStatus.FAILED
                     self.chat_timings.append(ct)
-                    break
+                    continue
 
             chat_start_time = time.time()
 
@@ -1771,8 +1829,9 @@ class ChatExporter:
                         self.chat_timings.append(ct)
                         break
                 else:
-                    # A fully successful export resets the consecutive counter
+                    # A fully successful export resets the consecutive counters
                     self._consecutive_recovery_count = 0
+                    self._consecutive_verify_failure_count = 0
 
             except Exception as e:
                 error_msg = str(e)

--- a/whatsapp_chat_autoexport/export/chat_exporter.py
+++ b/whatsapp_chat_autoexport/export/chat_exporter.py
@@ -522,6 +522,9 @@ class ChatExporter:
 
             # CRITICAL: Verify WhatsApp is still accessible before each export.
             # If verification fails, attempt session recovery before aborting.
+            # Halt-precedence: cascade limit (#27) fires BEFORE the recovery
+            # limit, so a regressed verifier halts the batch without spending
+            # recovery budget on doomed retries.
             if not self.driver.verify_whatsapp_is_open():
                 self._consecutive_verify_failure_count += 1
                 state_manager = self._get_state_manager()
@@ -1705,6 +1708,9 @@ class ChatExporter:
 
             # CRITICAL: Verify WhatsApp is still accessible before each export.
             # If verification fails, attempt session recovery before aborting.
+            # Halt-precedence: cascade limit (#27) fires BEFORE the recovery
+            # limit, so a regressed verifier halts the batch without spending
+            # recovery budget on doomed retries.
             if not self.driver.verify_whatsapp_is_open():
                 self._consecutive_verify_failure_count += 1
                 if self._check_consecutive_verify_failure_limit():

--- a/whatsapp_chat_autoexport/export/whatsapp_driver.py
+++ b/whatsapp_chat_autoexport/export/whatsapp_driver.py
@@ -1269,65 +1269,6 @@ class WhatsAppDriver:
 
             self.logger.success(f"✓ Activity confirmed safe: {current_activity}")
 
-            # Check 3: Verify we can see WhatsApp UI elements
-            self.logger.info("Checking for WhatsApp UI elements...")
-
-            # Try to find common WhatsApp elements
-            whatsapp_elements_found = False
-
-            # Look for chat list elements
-            try:
-                chat_elements = self.driver.find_elements("id", "com.whatsapp:id/conversations_row_contact_name")
-                if len(chat_elements) > 0:
-                    self.logger.success(f"✓ Found {len(chat_elements)} chat elements")
-                    whatsapp_elements_found = True
-            except Exception as e:
-                self.logger.debug_msg(f"No chat elements found: {e}")
-
-            # Look for toolbar (present on most WhatsApp screens)
-            try:
-                toolbar = self.driver.find_elements("id", "com.whatsapp:id/toolbar")
-                if len(toolbar) > 0:
-                    self.logger.success("✓ Found WhatsApp toolbar")
-                    whatsapp_elements_found = True
-            except Exception as e:
-                self.logger.debug_msg(f"No toolbar found: {e}")
-
-            # Look for action bar (another common element)
-            try:
-                action_bar = self.driver.find_elements("id", "com.whatsapp:id/action_bar")
-                if len(action_bar) > 0:
-                    self.logger.success("✓ Found WhatsApp action bar")
-                    whatsapp_elements_found = True
-            except Exception as e:
-                self.logger.debug_msg(f"No action bar found: {e}")
-
-            # Look for menu button
-            try:
-                menu_button = self.driver.find_elements("id", "com.whatsapp:id/menuitem_search")
-                if len(menu_button) > 0:
-                    self.logger.success("✓ Found WhatsApp menu button")
-                    whatsapp_elements_found = True
-            except Exception as e:
-                self.logger.debug_msg(f"No menu button found: {e}")
-
-            if not whatsapp_elements_found:
-                self.logger.error("=" * 70)
-                self.logger.error("❌ CRITICAL FAILURE: No WhatsApp UI elements found!")
-                self.logger.error("=" * 70)
-                self.logger.error("Package is com.whatsapp but UI is not accessible.")
-                self.logger.error("")
-                self.logger.error("This could mean:")
-                self.logger.error("  - Phone is locked but showing WhatsApp in background")
-                self.logger.error("  - WhatsApp is loading but not ready")
-                self.logger.error("  - Dialog or overlay is blocking WhatsApp UI")
-                self.logger.error("")
-                self.logger.error("⚠️  STOPPING to prevent accidental system UI interaction!")
-                self.logger.error("=" * 70)
-                return False
-
-            self.logger.success("✓ WhatsApp UI elements accessible")
-
             # Check 4: Final lock screen check
             is_locked, lock_reason = self.check_if_phone_locked()
             if is_locked:

--- a/whatsapp_chat_autoexport/export/whatsapp_driver.py
+++ b/whatsapp_chat_autoexport/export/whatsapp_driver.py
@@ -1269,7 +1269,9 @@ class WhatsAppDriver:
 
             self.logger.success(f"✓ Activity confirmed safe: {current_activity}")
 
-            # Check 4: Final lock screen check
+            # Final lock screen check
+            # (A legacy resource-ID probe sat between the activity check and this
+            # lock check; removed in #27 because it hard-failed on Material 3.)
             is_locked, lock_reason = self.check_if_phone_locked()
             if is_locked:
                 self.logger.error("=" * 70)


### PR DESCRIPTION
## Summary
- Delete Check 3 (legacy resource-ID probe) from `verify_whatsapp_is_open()` — package + activity + lock-check are sufficient and survive WhatsApp UI redesigns.
- Add `MAX_CONSECUTIVE_VERIFY_FAILURES = 3` cascade-halt in `ChatExporter` so a future verifier regression cannot poison more than 3 chats in a batch.
- 5 new unit tests + 2 updated recovery tests; CLAUDE.md refreshed.

Closes #27

## Agent ran
- [x] Spec: `docs/superpowers/specs/2026-04-30-relax-verify-whatsapp-is-open-design.md`
- [x] Plan: `docs/superpowers/plans/2026-04-30-relax-verify-whatsapp-is-open.md`
- [x] Pre-flight CI: `poetry run pytest tests/unit/ tests/integration/ -m "not requires_api and not requires_device and not requires_drive"` — 1211 passed; 65 pre-existing failures on `main` (verified independent of this branch, user-accepted)
- [x] Verification: `unit-tests` recipe (per `.claude/testing.md`) — artifact at `assets/verification/27/unit-tests/pytest.log`
- [x] Self-review: PASS (`Ship it`) — see `assets/verification/27/review-1.md`. Two minor findings applied as `7f0f8e5`; two suggestions deferred with logged reasoning.
- [x] Trail: `assets/verification/27/flow.log`

## Mode
`--guided`

## Human should eyeball
- [ ] Diff doesn't contain anything surprising
- [ ] `whatsapp_chat_autoexport/export/whatsapp_driver.py` — verifier shrinkage reads cleanly end-to-end
- [ ] `whatsapp_chat_autoexport/export/chat_exporter.py` — cascade-halt + `break → continue` change is the right call
- [ ] CLAUDE.md refresh accurately reflects the new verifier contract
- [ ] Merge when happy

## Notes for the reviewer
- The `break → continue` change on the recovery-failure-fallthrough path was a deliberate deviation from the original plan, justified during the build phase: without it, the new cascade counter would be dead code (the old `break` always fires first). The two affected `test_export_recovery.py` tests were renamed and updated to pin the new semantics.
- Selector updates for `export_chat_option` / `chat_list_item` / `toolbar` / `menu_button` are explicitly **out of scope** for this PR — they need real Appium Inspector dumps from a 2.26 device. Filing a separate issue is appropriate.
- The 65 pre-existing test failures (`test_pipeline_progress.py`, `test_output_builder.py`, several `tests/integration/test_*_command.py`) all fail with `TypeError: SpecF...` and exist on `main` before this branch. They are unrelated to the verifier and should be tracked separately.

## Related
- Diagnosis: `docs/solutions/integration-issues/whatsapp-material3-resource-id-allowlist-2026-04-30.md` (full root-cause + 6 Open Questions, all resolved by this PR)
- `docs/failure-reports/2026-04-16-full-run-pause.md` — separate verifier failure mode (focus-return race); not addressed here, but the simplified verifier reduces surface area
- `docs/plans/2026-04-17-001-fix-full-run-failures-plan.md` — active plan; cross-references this work