### PR TITLE
fix(output): SpecFormatter requires contact_name; construct per-chat

### DIFF
--- a/whatsapp_chat_autoexport/output/output_builder.py
+++ b/whatsapp_chat_autoexport/output/output_builder.py
@@ -53,7 +53,6 @@ class OutputBuilder:
         self.logger = logger or Logger()
         self.parser = TranscriptParser(logger=logger)
         self.format_version = format_version
-        self._spec_formatter = SpecFormatter()
         self._index_builder = IndexBuilder()
 
     def build_output(
@@ -314,12 +313,15 @@ class OutputBuilder:
         transcript_path = contact_dir / "transcript.md"
         index_path = contact_dir / "index.md"
 
-        # Format content via delegates
-        transcript_content = self._spec_formatter.format_transcript(
-            messages=messages,
-            chat_jid=chat_jid,
+        # SpecFormatter is per-chat (stores contact_name / chat_jid as instance
+        # state used during formatting), so construct one here for this chat.
+        spec_formatter = SpecFormatter(
             contact_name=contact_name,
+            chat_jid=chat_jid,
         )
+
+        # Format content via delegates
+        transcript_content = spec_formatter.format_transcript(messages=messages)
         index_content = self._index_builder.build_index(
             messages=messages,
             chat_jid=chat_jid,


### PR DESCRIPTION
## Summary
Pre-existing bug surfaced by the convention-alignment effort. `OutputBuilder.__init__` was constructing `SpecFormatter()` with zero args at init time, but `SpecFormatter` requires `contact_name` (it's per-chat instance state).

Fix: construct `SpecFormatter` inside `_build_v2_transcript` with the per-chat args already in scope; drop the incorrect `chat_jid=` / `contact_name=` kwargs in the `format_transcript` call (those values are read from `self` after construction).

No public API change to `OutputBuilder`.

Closes #31.

## Test plan
- [x] `poetry run pytest -m "not requires_api and not requires_device and not requires_drive"` — failure count dropped from 66 to 34 (32 fixes, 0 new failures).
- [x] Remaining 34 failures are pre-existing bugs in unrelated code paths (e.g. `sync.py` calls `SpecFormatter(user_display_name=...)`, which has never been a valid kwarg) — out of scope for this PR.
- [x] Diff comparison of failure lists confirms zero new failures introduced.