### PR TITLE
fix(cli): SpecFormatter call-sites in sync/ingest/migrate/rebuild

### DIFF
--- a/whatsapp_chat_autoexport/cli/commands/ingest.py
+++ b/whatsapp_chat_autoexport/cli/commands/ingest.py
@@ -60,7 +60,6 @@ def _ingest_chat(
     chat_name: str,
     appium_messages: List[Message],
     output_dir: Path,
-    spec_formatter: SpecFormatter,
     index_builder: IndexBuilder,
     dry_run: bool,
 ) -> Dict[str, Any]:
@@ -108,12 +107,15 @@ def _ingest_chat(
     # Ensure chat directory exists
     chat_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write transcript.md via SpecFormatter (atomic write)
-    transcript_content = spec_formatter.format_transcript(
-        messages=merged,
-        chat_jid=chat_name,
+    # SpecFormatter is per-chat (stores contact_name / chat_jid as instance
+    # state used during formatting), so construct one here for this chat.
+    spec_formatter = SpecFormatter(
         contact_name=chat_name,
+        chat_jid=chat_name,
     )
+
+    # Write transcript.md via SpecFormatter (atomic write)
+    transcript_content = spec_formatter.format_transcript(messages=merged)
     _atomic_write(transcript_md, transcript_content)
 
     # Write/update index.md via IndexBuilder
@@ -204,7 +206,9 @@ def run_ingest(
     _progress(f"Found {len(chats)} chat(s) in Appium export")
 
     # ---- 4. Create formatters ----
-    spec_formatter = SpecFormatter(user_display_name=user_display_name)
+    # SpecFormatter is built per-chat inside _ingest_chat (it stores
+    # contact_name / chat_jid as instance state); only IndexBuilder is
+    # safe to share across chats here.
     index_builder = IndexBuilder(user_display_name=user_display_name)
 
     # ---- 5. Per-chat ingest loop ----
@@ -220,7 +224,6 @@ def run_ingest(
                 chat_name=chat.name,
                 appium_messages=appium_messages,
                 output_dir=output_dir,
-                spec_formatter=spec_formatter,
                 index_builder=index_builder,
                 dry_run=dry_run,
             )

--- a/whatsapp_chat_autoexport/cli/commands/migrate.py
+++ b/whatsapp_chat_autoexport/cli/commands/migrate.py
@@ -91,7 +91,6 @@ def _find_legacy_transcripts(input_dir: Path) -> List[Path]:
 def _migrate_chat(
     transcript_path: Path,
     input_dir: Path,
-    spec_formatter: SpecFormatter,
     index_builder: IndexBuilder,
     no_backup: bool,
     dry_run: bool,
@@ -139,12 +138,15 @@ def _migrate_chat(
     # Ensure chat directory exists (for flat layout migration)
     chat_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write transcript.md via SpecFormatter
-    transcript_content = spec_formatter.format_transcript(
-        messages=messages,
-        chat_jid=chat_name,
+    # SpecFormatter is per-chat (stores contact_name / chat_jid as instance
+    # state used during formatting), so construct one here for this chat.
+    spec_formatter = SpecFormatter(
         contact_name=chat_name,
+        chat_jid=chat_name,
     )
+
+    # Write transcript.md via SpecFormatter
+    transcript_content = spec_formatter.format_transcript(messages=messages)
     transcript_md = chat_dir / "transcript.md"
     _atomic_write(transcript_md, transcript_content)
 
@@ -243,7 +245,9 @@ def run_migrate(
     _progress(f"Found {len(transcripts)} legacy transcript(s)")
 
     # ---- 3. Create formatters ----
-    spec_formatter = SpecFormatter(user_display_name=user_display_name)
+    # SpecFormatter is built per-chat inside _migrate_chat (it stores
+    # contact_name / chat_jid as instance state); only IndexBuilder is
+    # safe to share across chats here.
     index_builder = IndexBuilder(user_display_name=user_display_name)
 
     # ---- 4. Per-chat migration loop ----
@@ -259,7 +263,6 @@ def run_migrate(
             chat_result = _migrate_chat(
                 transcript_path=transcript_path,
                 input_dir=input_dir,
-                spec_formatter=spec_formatter,
                 index_builder=index_builder,
                 no_backup=no_backup,
                 dry_run=dry_run,

--- a/whatsapp_chat_autoexport/cli/commands/rebuild.py
+++ b/whatsapp_chat_autoexport/cli/commands/rebuild.py
@@ -179,7 +179,9 @@ def run_rebuild(
     _progress(f"Fetched {len(messages)} messages")
 
     # ---- 5. Create formatters ----
-    spec_formatter = SpecFormatter(user_display_name=user_display_name)
+    # SpecFormatter is per-chat (stores contact_name / chat_jid as instance
+    # state used during formatting), so it is built below once chat
+    # identifiers are resolved. IndexBuilder is shareable across chats.
     index_builder = IndexBuilder(user_display_name=user_display_name)
 
     # ---- 6. Write transcript.md + index.md ----
@@ -187,13 +189,14 @@ def run_rebuild(
     chat_dir = output_dir / folder_name
     chat_dir.mkdir(parents=True, exist_ok=True)
 
+    spec_formatter = SpecFormatter(
+        contact_name=chat.name or folder_name,
+        chat_jid=chat.jid,
+    )
+
     # Write transcript.md
     transcript_path = chat_dir / "transcript.md"
-    transcript_content = spec_formatter.format_transcript(
-        messages=messages,
-        chat_jid=chat.jid,
-        contact_name=chat.name or folder_name,
-    )
+    transcript_content = spec_formatter.format_transcript(messages=messages)
     _atomic_write(transcript_path, transcript_content)
     _progress(f"Wrote {transcript_path}")
 

--- a/whatsapp_chat_autoexport/cli/commands/sync.py
+++ b/whatsapp_chat_autoexport/cli/commands/sync.py
@@ -203,7 +203,6 @@ def _sync_chat(
     mcp_source: MCPSource,
     state: MCPState,
     output_dir: Path,
-    spec_formatter: SpecFormatter,
     index_builder: IndexBuilder,
     overlap_minutes: int,
     dry_run: bool,
@@ -281,12 +280,15 @@ def _sync_chat(
     # Ensure chat directory exists
     chat_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write transcript.md via SpecFormatter (atomic write)
-    transcript_content = spec_formatter.format_transcript(
-        messages=all_messages,
-        chat_jid=jid,
+    # SpecFormatter is per-chat (stores contact_name / chat_jid as instance
+    # state used during formatting), so construct one here for this chat.
+    spec_formatter = SpecFormatter(
         contact_name=chat.name or folder_name,
+        chat_jid=jid,
     )
+
+    # Write transcript.md via SpecFormatter (atomic write)
+    transcript_content = spec_formatter.format_transcript(messages=all_messages)
     _atomic_write(transcript_path, transcript_content)
 
     # Write/update index.md via IndexBuilder
@@ -431,7 +433,9 @@ def run_sync(
         summary["voice_retry"] = voice_stats
 
     # ---- 6. Create formatters ----
-    spec_formatter = SpecFormatter(user_display_name=user_display_name)
+    # SpecFormatter is built per-chat inside _sync_chat (it stores
+    # contact_name / chat_jid as instance state); only IndexBuilder is
+    # safe to share across chats here.
     index_builder = IndexBuilder(user_display_name=user_display_name)
 
     # ---- 7. Per-chat sync loop ----
@@ -443,7 +447,6 @@ def run_sync(
                 mcp_source=mcp_source,
                 state=state,
                 output_dir=output_dir,
-                spec_formatter=spec_formatter,
                 index_builder=index_builder,
                 overlap_minutes=overlap_minutes,
                 dry_run=dry_run,


### PR DESCRIPTION
## Summary

Same class of bug as #31/#32, now in the four CLI command files. Each constructs `SpecFormatter(user_display_name=...)` — but `user_display_name` is a valid kwarg on `IndexBuilder`, **not** on `SpecFormatter` (which takes `contact_name` + `chat_jid`). The broken line was copy-pasted from the adjacent `IndexBuilder(...)` call.

`SpecFormatter` stores `contact_name`/`chat_jid` as instance state used during formatting, so it must be constructed per-chat — not once at the top of a run.

## Files changed (4)

- `whatsapp_chat_autoexport/cli/commands/sync.py`
- `whatsapp_chat_autoexport/cli/commands/ingest.py`
- `whatsapp_chat_autoexport/cli/commands/migrate.py`
- `whatsapp_chat_autoexport/cli/commands/rebuild.py`

Same fix pattern in each: drop the broken init-time call, build `SpecFormatter(contact_name=..., chat_jid=...)` inside the per-chat loop, and call `format_transcript(messages=...)` only. In `sync/ingest/migrate` the `spec_formatter` param is also removed from the `_sync_chat` / `_ingest_chat` / `_migrate_chat` helpers (each now builds its own).

## Test count delta (filter: `-m "not requires_api and not requires_device and not requires_drive"`)

| | failed | passed |
|---|---:|---:|
| origin/main (before) | 35 | 1244 |
| this branch (after) | 1 | 1278 |

The one remaining failure is `tests/integration/test_spec_output.py::test_pipeline_legacy_format_unchanged` — pre-existing on main, unrelated to this fix (it expects the legacy `transcript.txt` output path, not the spec-format path).

## Test plan

- [x] `poetry run pytest -m "not requires_api and not requires_device and not requires_drive"` — 1278 pass / 1 pre-existing fail
- [x] No `SpecFormatter` call site left in the codebase with `user_display_name` kwarg (`grep -rn "SpecFormatter(" --include="*.py"`)
- [x] All four CLI commands now build `SpecFormatter` with `contact_name=` / `chat_jid=` per chat

Closes #33.