### PR TITLE
fix(pipeline): legacy output path writes transcript.txt (unblock red CI)

### DIFF
--- a/whatsapp_chat_autoexport/pipeline.py
+++ b/whatsapp_chat_autoexport/pipeline.py
@@ -638,13 +638,16 @@ class WhatsAppPipeline:
         if self.config.output_format == "spec":
             return self._phase4_build_spec_outputs(transcript_files)
 
-        # Legacy format (default)
+        # Legacy format (default). Force format_version="legacy" so the
+        # OutputBuilder writes transcript.txt even when its instance default
+        # was constructed with "v2" (the per-call arg overrides the instance).
         results = self.output_builder.batch_build_outputs(
             transcript_files,
             self.config.output_dir,
             include_transcriptions=self.config.include_transcriptions,
             copy_media=self.config.include_media,
-            on_progress=self.on_progress
+            on_progress=self.on_progress,
+            format_version="legacy",
         )
 
         output_dirs = [r['output_dir'] for r in results]


### PR DESCRIPTION
## Summary
`main`'s CI had been red for 12+ consecutive runs. Investigation (issue #38) found the full suite reported 7 failures, but only **one** is a genuine, reproducible-in-isolation code bug:

- `_phase4_build_outputs` called `OutputBuilder.batch_build_outputs()` without `format_version`, so the builder used its instance default (`"v2"`) and wrote `transcript.md` instead of `transcript.txt` on the legacy path. Fixed by passing `format_version="legacy"` explicitly at the call site (the per-call arg overrides the instance default).

The other 6 reported failures (4× `test_connect_pane_preflight` `call_from_thread`, 1× `test_spec_output` companion-notes, 1× `test_headless` no-transcribe) pass against this base (`7198008`) both in isolation and in the full suite — they appear to have been base/ordering artifacts of the earlier CI run, not code bugs. **Letting CI be the authoritative judge here.** If any resurface in CI, the `call_from_thread` one is a real order-sensitive Textual teardown leak worth a follow-up.

Scope kept to the one real fix — no opportunistic reformatting (the convention train's PR 4 will sweep ruff/mypy project-wide).

Closes #38.

## Test plan
- [x] `uv run pytest -m "not requires_api and not requires_device and not requires_drive"` → **1285 passed, 6 deselected** (matches CI's deselect set), run twice.
- [x] Verified the fix is correct against `OutputBuilder`: `effective_format = format_version or self.format_version`; `"legacy"` → `transcript.txt`.