### PR TITLE
ci(release-please): bump release-please-action v4 → v5 (Node 24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
GitHub forces the Node 24 runtime on Actions runners from **2026-06-16**. `release-please-action@v4` runs on Node 20 and emits a deprecation warning.

`v5.0.0`'s only breaking change is the runtime upgrade ([#1188](https://github.com/googleapis/release-please-action/issues/1188)); the `config-file`/`manifest-file` inputs this workflow uses are unchanged, so this is a one-line mechanical bump.

Part of a cross-repo sweep.